### PR TITLE
Add KernelGenBench to FlagOS 2.1 RC0 manifest

### DIFF
--- a/release/rc0-branch.sh
+++ b/release/rc0-branch.sh
@@ -52,6 +52,7 @@ RC0_BRANCH["flagaudio"]="v0.2-rc0"
 RC0_BRANCH["flagattention"]="v0.3-rc0"
 RC0_BRANCH["vllm-plugin-fl"]="v0.2.0-rc0"
 RC0_BRANCH["kernelgen"]="v2.1.0-rc0"
+RC0_BRANCH["kernelgenbench"]="v0.1.0-rc0"
 RC0_BRANCH["skills"]="v1.1.0-rc0"
 RC0_BRANCH["sglang-plugin-fl"]="v0.1.0-rc0"
 RC0_BRANCH["pytorch-plugin-fl"]="v0.1.0-rc0"
@@ -67,7 +68,7 @@ MODULES=(
   "flagtree" "flagcx" "flaggems" "flagfft" "flagsparse" "flagdnn" "flagblas"
   "flagtensor" "flagaudio" "flagattention" "pytorch-plugin-fl" "vllm-plugin-fl"
   "sglang-plugin-fl" "transformerengine-fl" "megatron-lm-fl" "verl-fl"
-  "flagscale" "flagquantum" "flagos-robo" "kernelgen" "flagrelease" "skills"
+  "flagscale" "flagquantum" "flagos-robo" "kernelgen" "kernelgenbench" "flagrelease" "skills"
 )
 for m in "${MODULES[@]}"; do
   DEFAULT_BRANCH[$m]="main"

--- a/release/release-2.1-rc0.yaml
+++ b/release/release-2.1-rc0.yaml
@@ -196,6 +196,13 @@ repositories:
     # 分支: v2.1.0-rc0
     # 当前版本: v2.0.0 / 默认分支: main
 
+  kernelgenbench:
+    type: git
+    url: https://github.com/flagos-ai/KernelGenBench.git
+    version: v0.1.0-rc0.1
+    # 分支: v0.1.0-rc0
+    # 当前版本: 无 tag / 默认分支: main
+
   flagrelease:
     type: git
     url: https://github.com/flagos-ai/flagrelease.git


### PR DESCRIPTION
## Summary

Add the new KernelGenBench repo (https://github.com/flagos-ai/KernelGenBench) to the release management files.

- KernelGenBench has no prior tags → C class → `v0.1.0-rc0` / `v0.1.0-rc0.1`
- Added to `release-2.1-rc0.yaml` manifest (L3 layer)
- Added to `rc0-branch.sh` script