### PR TITLE
fep(sig-kernelgen): KernelGenBench - Multi-Chip Triton Kernel Generation Benchmark

### DIFF
--- a/fep/sig-kernelgen/0004-kernelgenbench.md
+++ b/fep/sig-kernelgen/0004-kernelgenbench.md
@@ -41,6 +41,12 @@ After installing via `pip install kernelgenbench`, users can:
 3. Automatically run correctness validation (compared against PyTorch reference)
 4. Output pass rate and performance reports
 
+### Distribution
+
+- Provide wheel (.whl) packages for easy installation
+- Build command: `python setup.py bdist_wheel` or `pip wheel .`
+- Per-platform requirements files under `requirements/` (following FlagGems convention)
+
 ## Design Details
 
 ### Architecture

--- a/fep/sig-kernelgen/0004-kernelgenbench.md
+++ b/fep/sig-kernelgen/0004-kernelgenbench.md
@@ -1,6 +1,6 @@
 # FEP-0004: KernelGenBench - Multi-Chip Triton Kernel Generation Benchmark
 
-**Status:** `Implementable`
+**Status:** `Implemented`
 
 **Created:** 2025-05-25
 

--- a/fep/sig-kernelgen/0004-kernelgenbench.md
+++ b/fep/sig-kernelgen/0004-kernelgenbench.md
@@ -14,83 +14,83 @@
 
 ## Summary
 
-KernelGenBench 是一个端到端的 Triton kernel 生成与验证基准测试框架，支持 LLM 自动生成 Triton kernel、正确性验证和性能评测。本次作为 FlagOS 2.1 新组件首次发布，支持 6 款芯片平台。
+KernelGenBench is an end-to-end Triton kernel generation and verification benchmark framework. It supports LLM-driven Triton kernel generation, correctness validation, and performance benchmarking. This is its initial release as a new component in FlagOS 2.1, supporting 6 chip platforms.
 
 ## Motivation
 
-当前缺乏统一的跨平台 Triton kernel 生成评估标准。各芯片厂商的 Triton 支持程度不一，需要一个自动化框架来评估 LLM 生成 kernel 的正确性和性能，为算子开发提供可量化的基准。
+There is currently no unified cross-platform evaluation standard for Triton kernel generation. Different chip vendors have varying levels of Triton support, and an automated framework is needed to assess the correctness and performance of LLM-generated kernels, providing quantifiable benchmarks for operator development.
 
 ### Goals
 
-- 提供标准化的 Triton kernel 生成评测流程（生成 → 验证 → 性能测试）
-- 支持 3 个子数据集：aten (110 ops)、vllm (50 ops)、cublas (50 ops)
-- 覆盖 6 款芯片平台：NVIDIA、Ascend、MUSA、Hygon、Iluvatar、MetaX
-- 支持 Pass@K 迭代验证流程
-- 集成 3 种 SOTA agent 方法：AutoKernel、AKO4ALL、cuda-optimized-skill
+- Provide a standardized Triton kernel generation evaluation pipeline (generation → verification → performance testing)
+- Support 3 sub-datasets: aten (110 ops), vllm (50 ops), cublas (50 ops)
+- Cover 6 chip platforms: NVIDIA, Ascend, MUSA, Hygon, Iluvatar, MetaX
+- Support Pass@K iterative verification workflow
+- Integrate 3 SOTA agent methods: AutoKernel, AKO4ALL, cuda-optimized-skill
 
 ### Non-Goals
 
-- 不负责 Triton 编译器本身的适配工作
-- 不提供芯片驱动层面的支持
+- Not responsible for Triton compiler adaptation
+- Not providing chip driver-level support
 
 ## Proposal
 
-用户通过 `pip install kernelgenbench` 安装后，可以：
-1. 选择目标芯片平台和子数据集
-2. 配置 LLM 后端生成 Triton kernel
-3. 自动运行正确性验证（与 PyTorch 参考实现对比）
-4. 输出 pass rate 和性能报告
+After installing via `pip install kernelgenbench`, users can:
+1. Select the target chip platform and sub-dataset
+2. Configure the LLM backend to generate Triton kernels
+3. Automatically run correctness validation (compared against PyTorch reference)
+4. Output pass rate and performance reports
 
 ## Design Details
 
-### 架构
+### Architecture
 
-三层结构：
-1. **Generator Layer** — LLM 生成 Triton kernel 代码
-2. **Sandbox/Verifier Layer** — 隔离执行与正确性验证
-3. **Benchmark Layer** — 性能评测与结果收集
+Three-layer structure:
+1. **Generator Layer** — LLM generates Triton kernel code
+2. **Sandbox/Verifier Layer** — Isolated execution and correctness verification
+3. **Benchmark Layer** — Performance benchmarking and result collection
 
-### 多芯片支持
+### Multi-Chip Support
 
-通过 `device_manager.py` 自动检测当前硬件平台，加载对应的 prompt 模板和编译约束，实现一套代码适配多平台。
+The `device_manager.py` module automatically detects the current hardware platform, loads the corresponding prompt templates and compilation constraints, enabling a single codebase to work across multiple platforms.
 
 ## Test Plan
 
-### 功能验证
+### Functional Verification
 
-| 模块 | 验证 Case | 说明 |
-|------|-----------|------|
-| Agent 评测 | `bash agent_bench/test_ops.sh add` | 单算子端到端：生成 prompt → agent 生成 kernel → 验证 |
-| 全量评测 | `bash agent_bench/test_ops.sh -d KernelGenBench` | 全数据集 agent 评测 |
-| 单算子生成与验证 | `python scripts/generate_kernel_and_verify.py --op-name add` | 单算子 Pass@K 生成与验证 |
-| 全量生成与验证 | `python scripts/generate_kernel_and_verify.py --dataset KernelGenBench` | 全数据集 Pass@K 生成与验证 |
-| 子数据集覆盖 | 分别运行 aten/vllm/cublas 数据集 | 各数据集算子列表完整、可加载 |
-| SOTA Agent | `bash agent_bench/test_autokernel.sh` / `test_ako4all.sh` / `test_cuda_optimized_skill.sh` | 三种 agent 方法可正常运行并输出结果 |
-| 设备检测 | `agent_bench/device_manager.py` | 各平台设备自动检测、模板正确加载 |
+| Module | Test Case | Description |
+|--------|-----------|-------------|
+| Agent benchmark | `bash agent_bench/test_ops.sh add` | Single-operator end-to-end: generate prompt → agent generates kernel → verify |
+| Full benchmark | `bash agent_bench/test_ops.sh -d KernelGenBench` | Full dataset agent benchmark |
+| Single-op generation | `python scripts/generate_kernel_and_verify.py --op-name add` | Single-operator Pass@K generation and verification |
+| Full generation | `python scripts/generate_kernel_and_verify.py --dataset KernelGenBench` | Full dataset Pass@K generation and verification |
+| Sub-dataset coverage | Run aten/vllm/cublas datasets separately | All dataset operator lists are complete and loadable |
+| SOTA Agent | `bash agent_bench/test_autokernel.sh` / `test_ako4all.sh` / `test_cuda_optimized_skill.sh` | All three agent methods run successfully and produce results |
+| Device detection | `agent_bench/device_manager.py` | All platforms auto-detected, correct templates loaded |
 
-### 性能验证
+### Performance Verification
 
-| 指标 | 要求 |
-|------|------|
-| Pass@1 通过率 | aten 数据集 ≥ 60% |
-| Pass@10 通过率 | aten 数据集 ≥ 80% |
-| 生成 kernel Speedup | 与 PyTorch eager 对比，平均 speedup ≥ 1.0x |
+| Metric | Requirement |
+|--------|-------------|
+| Pass@1 rate | aten dataset >= 60% |
+| Pass@10 rate | aten dataset >= 80% |
+| Generated kernel speedup | Average speedup >= 1.0x vs PyTorch eager |
 
-### 兼容性验证
+### Compatibility Verification
 
-| 平台 | 验证内容 |
-|------|----------|
-| NVIDIA | 设备检测、模板加载、kernel 编译运行、正确性验证通过 |
-| Ascend | 设备检测、模板加载、kernel 编译运行、正确性验证通过 |
-| MUSA | 设备检测、模板加载、kernel 编译运行、正确性验证通过 |
-| Hygon | 设备检测、模板加载、kernel 编译运行、正确性验证通过 |
-| Iluvatar | 设备检测、模板加载、kernel 编译运行、正确性验证通过 |
-| MetaX | 设备检测、模板加载、kernel 编译运行、正确性验证通过 |
+| Platform | Verification |
+|----------|--------------|
+| NVIDIA | Device detection, template loading, kernel compilation and execution, correctness validation passed |
+| Ascend | Device detection, template loading, kernel compilation and execution, correctness validation passed |
+| MUSA | Device detection, template loading, kernel compilation and execution, correctness validation passed |
+| Hygon | Device detection, template loading, kernel compilation and execution, correctness validation passed |
+| Iluvatar | Device detection, template loading, kernel compilation and execution, correctness validation passed |
+| MetaX | Device detection, template loading, kernel compilation and execution, correctness validation passed |
 
 ## Related PRs
 
-- [ ] flagos-ai/KernelGenBench — 主仓库首次发布
+- [ ] flagos-ai/KernelGenBench — Initial release
 
 ## Implementation History
 
-- 2025-05-25: FEP 创建
+- 2025-05-25: FEP created

--- a/fep/sig-kernelgen/0004-kernelgenbench.md
+++ b/fep/sig-kernelgen/0004-kernelgenbench.md
@@ -68,14 +68,6 @@ The `device_manager.py` module automatically detects the current hardware platfo
 | SOTA Agent | `bash agent_bench/test_autokernel.sh` / `test_ako4all.sh` / `test_cuda_optimized_skill.sh` | All three agent methods run successfully and produce results |
 | Device detection | `agent_bench/device_manager.py` | All platforms auto-detected, correct templates loaded |
 
-### Performance Verification
-
-| Metric | Requirement |
-|--------|-------------|
-| Pass@1 rate | aten dataset >= 60% |
-| Pass@10 rate | aten dataset >= 80% |
-| Generated kernel speedup | Average speedup >= 1.0x vs PyTorch eager |
-
 ### Compatibility Verification
 
 | Platform | Verification |

--- a/fep/sig-kernelgen/0004-kernelgenbench.md
+++ b/fep/sig-kernelgen/0004-kernelgenbench.md
@@ -1,4 +1,4 @@
-# FEP-NNNN: KernelGenBench - Multi-Chip Triton Kernel Generation Benchmark
+# FEP-0004: KernelGenBench - Multi-Chip Triton Kernel Generation Benchmark
 
 **Status:** `Implementable`
 

--- a/fep/sig-kernelgen/0004-kernelgenbench.md
+++ b/fep/sig-kernelgen/0004-kernelgenbench.md
@@ -85,6 +85,48 @@ The `device_manager.py` module automatically detects the current hardware platfo
 | Iluvatar | Device detection, template loading, kernel compilation and execution, correctness validation passed |
 | MetaX | Device detection, template loading, kernel compilation and execution, correctness validation passed |
 
+### Test Environment (Docker)
+
+NVIDIA / Hygon / Iluvatar / MetaX use the default FlagTree vendor images.
+Ascend and MUSA require the following specific images:
+
+#### Ascend NPU (910b)
+
+```bash
+docker run -dit --name svt-ascend \
+  --privileged --network=host --ipc=host --shm-size=64g \
+  --device=/dev/davinci0 --device=/dev/davinci1 \
+  --device=/dev/davinci2 --device=/dev/davinci3 \
+  --device=/dev/davinci4 --device=/dev/davinci5 \
+  --device=/dev/davinci6 --device=/dev/davinci7 \
+  --device=/dev/davinci_manager --device=/dev/hisi_hdc \
+  --volume /usr/local/sbin:/usr/local/sbin \
+  --volume /usr/local/Ascend/driver:/usr/local/Ascend/driver \
+  --volume /public-flash:/public-flash \
+  --volume /etc/ascend_install.info:/etc/ascend_install.info \
+  harbor.baai.ac.cn/flagtree/flagtree-ascend-910c-py311-torch2.6.0-cann8.5.0-ubuntu22.04-aarch64:202603 \
+  bash
+```
+
+#### MUSA (S5000)
+
+```bash
+IMAGE=harbor.baai.ac.cn/flagtree/flagtree-mthreads3.6-py310-torch2.7.1-musa5.1.0-ubuntu22.04:202605-base
+CONTAINER=flagtree-dev-xxx
+docker run -dit \
+    --network=host --pid=host --privileged \
+    --cap-add=SYS_PTRACE \
+    --shm-size 16gb \
+    --security-opt seccomp=unconfined \
+    -e MTHREADS_VISIBLE_DEVICES=all -e MTHREADS_DRIVER_CAPABILITIES=all \
+    -v /usr/lib/x86_64-linux-gnu:/usr/lib/x86_64-linux-gnu \
+    -v /lib/x86_64-linux-gnu:/lib/x86_64-linux-gnu \
+    -v /etc/alternatives:/etc/alternatives \
+    -v /etc/localtime:/etc/localtime:ro \
+    -v /data:/data -v /home:/home -v /tmp:/tmp \
+    -w /root --name ${CONTAINER} ${IMAGE} bash
+```
+
 ## Related PRs
 
 - [ ] flagos-ai/KernelGenBench — Initial release

--- a/fep/sig-kernelgen/0004-kernelgenbench.md
+++ b/fep/sig-kernelgen/0004-kernelgenbench.md
@@ -26,7 +26,7 @@ There is currently no unified cross-platform evaluation standard for Triton kern
 - Support 3 sub-datasets: aten (110 ops), vllm (50 ops), cublas (50 ops)
 - Cover 6 chip platforms: NVIDIA, Ascend, MUSA, Hygon, Iluvatar, MetaX
 - Support Pass@K iterative verification workflow
-- Integrate 3 SOTA agent methods: AutoKernel, AKO4ALL, cuda-optimized-skill
+- Integrate 3 kernel-specialized methods: AutoKernel, AKO4ALL, cuda-optimized-skill
 
 ### Non-Goals
 
@@ -71,7 +71,7 @@ The `device_manager.py` module automatically detects the current hardware platfo
 | Single-op generation | `python scripts/generate_kernel_and_verify.py --op-name add` | Single-operator Pass@K generation and verification |
 | Full generation | `python scripts/generate_kernel_and_verify.py --dataset KernelGenBench` | Full dataset Pass@K generation and verification |
 | Sub-dataset coverage | Run aten/vllm/cublas datasets separately | All dataset operator lists are complete and loadable |
-| SOTA Agent | `bash agent_bench/test_autokernel.sh` / `test_ako4all.sh` / `test_cuda_optimized_skill.sh` | All three agent methods run successfully and produce results |
+| Kernel-specialized methods | `bash agent_bench/test_autokernel.sh` / `test_ako4all.sh` / `test_cuda_optimized_skill.sh` | All three kernel-specialized methods run successfully and produce results |
 | Device detection | `agent_bench/device_manager.py` | All platforms auto-detected, correct templates loaded |
 
 ### Compatibility Verification

--- a/fep/sig-kernelgen/NNNN-kernelgenbench.md
+++ b/fep/sig-kernelgen/NNNN-kernelgenbench.md
@@ -1,0 +1,96 @@
+# FEP-NNNN: KernelGenBench - Multi-Chip Triton Kernel Generation Benchmark
+
+**Status:** `Implementable`
+
+**Created:** 2025-05-25
+
+**Owner:** @factnn
+
+**SIG:** sig-kernelgen
+
+**Target Version:** FlagOS 2.1
+
+---
+
+## Summary
+
+KernelGenBench 是一个端到端的 Triton kernel 生成与验证基准测试框架，支持 LLM 自动生成 Triton kernel、正确性验证和性能评测。本次作为 FlagOS 2.1 新组件首次发布，支持 6 款芯片平台。
+
+## Motivation
+
+当前缺乏统一的跨平台 Triton kernel 生成评估标准。各芯片厂商的 Triton 支持程度不一，需要一个自动化框架来评估 LLM 生成 kernel 的正确性和性能，为算子开发提供可量化的基准。
+
+### Goals
+
+- 提供标准化的 Triton kernel 生成评测流程（生成 → 验证 → 性能测试）
+- 支持 3 个子数据集：aten (110 ops)、vllm (50 ops)、cublas (50 ops)
+- 覆盖 6 款芯片平台：NVIDIA、Ascend、MUSA、Hygon、Iluvatar、MetaX
+- 支持 Pass@K 迭代验证流程
+- 集成 3 种 SOTA agent 方法：AutoKernel、AKO4ALL、cuda-optimized-skill
+
+### Non-Goals
+
+- 不负责 Triton 编译器本身的适配工作
+- 不提供芯片驱动层面的支持
+
+## Proposal
+
+用户通过 `pip install kernelgenbench` 安装后，可以：
+1. 选择目标芯片平台和子数据集
+2. 配置 LLM 后端生成 Triton kernel
+3. 自动运行正确性验证（与 PyTorch 参考实现对比）
+4. 输出 pass rate 和性能报告
+
+## Design Details
+
+### 架构
+
+三层结构：
+1. **Generator Layer** — LLM 生成 Triton kernel 代码
+2. **Sandbox/Verifier Layer** — 隔离执行与正确性验证
+3. **Benchmark Layer** — 性能评测与结果收集
+
+### 多芯片支持
+
+通过 `device_manager.py` 自动检测当前硬件平台，加载对应的 prompt 模板和编译约束，实现一套代码适配多平台。
+
+## Test Plan
+
+### 功能验证
+
+| 模块 | 验证 Case | 说明 |
+|------|-----------|------|
+| Agent 评测 | `bash agent_bench/test_ops.sh add` | 单算子端到端：生成 prompt → agent 生成 kernel → 验证 |
+| 全量评测 | `bash agent_bench/test_ops.sh -d KernelGenBench` | 全数据集 agent 评测 |
+| 单算子生成与验证 | `python scripts/generate_kernel_and_verify.py --op-name add` | 单算子 Pass@K 生成与验证 |
+| 全量生成与验证 | `python scripts/generate_kernel_and_verify.py --dataset KernelGenBench` | 全数据集 Pass@K 生成与验证 |
+| 子数据集覆盖 | 分别运行 aten/vllm/cublas 数据集 | 各数据集算子列表完整、可加载 |
+| SOTA Agent | `bash agent_bench/test_autokernel.sh` / `test_ako4all.sh` / `test_cuda_optimized_skill.sh` | 三种 agent 方法可正常运行并输出结果 |
+| 设备检测 | `agent_bench/device_manager.py` | 各平台设备自动检测、模板正确加载 |
+
+### 性能验证
+
+| 指标 | 要求 |
+|------|------|
+| Pass@1 通过率 | aten 数据集 ≥ 60% |
+| Pass@10 通过率 | aten 数据集 ≥ 80% |
+| 生成 kernel Speedup | 与 PyTorch eager 对比，平均 speedup ≥ 1.0x |
+
+### 兼容性验证
+
+| 平台 | 验证内容 |
+|------|----------|
+| NVIDIA | 设备检测、模板加载、kernel 编译运行、正确性验证通过 |
+| Ascend | 设备检测、模板加载、kernel 编译运行、正确性验证通过 |
+| MUSA | 设备检测、模板加载、kernel 编译运行、正确性验证通过 |
+| Hygon | 设备检测、模板加载、kernel 编译运行、正确性验证通过 |
+| Iluvatar | 设备检测、模板加载、kernel 编译运行、正确性验证通过 |
+| MetaX | 设备检测、模板加载、kernel 编译运行、正确性验证通过 |
+
+## Related PRs
+
+- [ ] flagos-ai/KernelGenBench — 主仓库首次发布
+
+## Implementation History
+
+- 2025-05-25: FEP 创建


### PR DESCRIPTION
## Summary

Add FEP for KernelGenBench, a multi-chip Triton kernel generation benchmark framework for FlagOS 2.1.

- 支持 6 款芯片平台：NVIDIA、Ascend、MUSA、Hygon、Iluvatar、MetaX
- 支持 3 个子数据集：aten (110 ops)、vllm (50 ops)、cublas (50 ops)
- 集成 3 种 SOTA agent 方法：AutoKernel、AKO4ALL、cuda-optimized-skill
- 包含完整 Test Plan（功能验证、性能验证、兼容性验证）

**Target Version:** FlagOS 2.1