### PR TITLE
docs: fix remaining Mermaid lexical error in English lifecycle diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ flowchart LR
     end
     P -.author writes.-> S
     IA -.approved by FEP Freeze.-> FF
-    CF -.impl. merged in module repos.-> T
+    CF -.implementation merged in module repos.-> T
     IM -.acceptance met at release.-> R
 
     OW([FEP Owner]):::role -.owns.-> P


### PR DESCRIPTION
Follow-up to #49, this time verified with the actual mermaid v11 parser before merging:

- `/tmp` parse test results: CN diagram OK; EN diagram **failed** with `Lexical error on line 10 ... CF -.impl. merged in module r` — the `.` in "impl." terminates the dotted-edge label (`-. label .->`) early.
- Fix: `impl.` → `implementation`. The exact committed block now passes `mermaid.parse()`.