### PR TITLE
docs: make lifecycle diagram version-agnostic

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,8 @@ flowchart LR
     subgraph Design["FEP status (design track)"]
         P[Provisional] --> IA[Implementable] --> IM[Implemented]
     end
-    subgraph Cycle["Release cycle (per version, e.g. 2.2)"]
-        S[Submit and review] --> FF[FEP Freeze<br/>08-15] --> CF[Code Freeze<br/>08-31] --> T[Testing<br/>09-01→26] --> R[Release<br/>09-28]
+    subgraph Cycle["Release cycle (repeats every version)"]
+        S[Submit and review] --> FF[FEP Freeze] --> CF[Code Freeze] --> T[Testing window] --> R[Release]
     end
     P -.author writes.-> S
     IA -.approved by FEP Freeze.-> FF
@@ -67,7 +67,7 @@ flowchart LR
 - **Release Manager** enforces the freeze dates and tracks progress via the milestone.
 - **Tester** validates each merged FEP against its Test Plan during the testing window.
 
-Full rules: [FEP lifecycle](fep/README.md#fep-lifecycle) · [2.2 schedule & freeze rules](release/2.2/schedule.md).
+Full rules: [FEP lifecycle](fep/README.md#fep-lifecycle). Concrete dates for the current cycle: [release/2.2/schedule.md](release/2.2/schedule.md).
 
 ## Community Navigation
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -47,8 +47,8 @@ flowchart LR
     subgraph Design["FEP 状态(设计轨道)"]
         P[Provisional] --> IA[Implementable] --> IM[Implemented]
     end
-    subgraph Cycle["版本周期(每个版本,如 2.2)"]
-        S[提交与评审] --> FF[FEP 冻结<br/>08-15] --> CF[代码冻结<br/>08-31] --> T[测试期<br/>09-01→26] --> R[发布<br/>09-28]
+    subgraph Cycle["版本周期(每个版本循环一次)"]
+        S[提交与评审] --> FF[FEP 冻结] --> CF[代码冻结] --> T[测试期] --> R[发布]
     end
     P -.作者撰写.-> S
     IA -.冻结前须批准.-> FF
@@ -67,7 +67,7 @@ flowchart LR
 - **Release Manager**:执行冻结日期,通过 milestone 追踪进度。
 - **测试者**:在测试期依据各 FEP 的 Test Plan 验证已合入的功能。
 
-完整规则:[FEP 生命周期](fep/README_CN.md#fep-生命周期) · [2.2 时间表与冻结规则](release/2.2/schedule_CN.md)。
+完整规则:[FEP 生命周期](fep/README_CN.md#fep-生命周期)。当前周期的具体日期见:[release/2.2/schedule_CN.md](release/2.2/schedule_CN.md)。
 
 ## 社区导航
 


### PR DESCRIPTION
The lifecycle diagram in the root READMEs carried 2.2-specific dates (08-15 / 08-31 / 09-01→26 / 09-28), which would go stale every cycle and duplicate the authoritative schedule file. Nodes are now generic (FEP Freeze / Code Freeze / Testing window / Release), the cycle subgraph is labeled "repeats every version", and the line under the diagram links to the current cycle's schedule for concrete dates. Both mermaid blocks pass mermaid v11 `parse()` (verified pre-commit).