### PR TITLE
docs: fix broken links, stale placeholders, and Rejected-status wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ Stay connected and engage with the FlagOS community:
 |---------|---------|---------|
 | 📧 **Email** | General inquiries and communication | contact@flagos.io |
 | 📱 **WeChat Official Account** | Updates and news | 智源FlagOpen |
-| 💬 **GitHub Discussions** | Technical discussions and Q&A | [Coming Soon] |
+| 💬 **GitHub Discussions** | Technical discussions and Q&A | [flagos-ai/community/discussions](https://github.com/flagos-ai/community/discussions) |
 | 📋 **Mailing List** | Announcements and community updates | [Coming Soon] |
 
 ## Code of Conduct

--- a/README_CN.md
+++ b/README_CN.md
@@ -75,7 +75,7 @@ flowchart LR
 
 | 入口 | 说明 |
 |------|------|
-| [GOVERNANCE.md](GOVERNANCE.md) | 社区治理规则与决策机制 |
+| [GOVERNANCE_CN.md](GOVERNANCE_CN.md) | 社区治理规则与决策机制 |
 | [MAINTAINERS.md](MAINTAINERS.md) | TSC + SIG Chair 名单 |
 | [sigs/](sigs/) | **SIG** — 所有 SIG 列表、章程、创建流程、OWNERS 规范、会议日历 |
 | [contributors/](contributors/) | 贡献者指南、角色定义、FEP 编写指引 |
@@ -144,7 +144,7 @@ FlagOS 项目包含多个专业化的代码仓库：
 ### 🏛️ 加入或创建 SIG
 SIG（特别兴趣小组）是技术工作的核心组织。每个 SIG 覆盖一个特定技术领域——算子、编译器、通信、训练等。
 - **[浏览现有 SIG](sigs/)** 找到你感兴趣的方向，参加例会
-- **[创建新 SIG](GOVERNANCE.md#sig-special-interest-group)** — 需 ≥1 名 Chair、≥1 名 Tech Lead、≥3 名初始成员、Charter 草案。向 TSC 提交 PR 即可发起
+- **[创建新 SIG](GOVERNANCE_CN.md#sig-special-interest-group)** — 需 ≥1 名 Chair、≥1 名 Tech Lead、≥3 名初始成员、Charter 草案。向 TSC 提交 PR 即可发起
 
 ## 交流渠道
 
@@ -155,7 +155,7 @@ SIG（特别兴趣小组）是技术工作的核心组织。每个 SIG 覆盖一
 | 📧 **邮箱** | 一般咨询和沟通 | contact@flagos.io |
 | 📱 **微信公众号** | 更新和新闻 | 智源FlagOpen |
 | 📺 **微信视频号** | 视频更新和公告 | 智源FlagOpen |
-| 💬 **GitHub Discussions** | 技术讨论和问答 | [即将推出] |
+| 💬 **GitHub Discussions** | 技术讨论和问答 | [flagos-ai/community/discussions](https://github.com/flagos-ai/community/discussions) |
 | 📋 **邮件列表** | 公告和社区更新 | [即将推出] |
 
 ## 行为准则
@@ -203,8 +203,8 @@ SIG（特别兴趣小组）是技术工作的核心组织。每个 SIG 覆盖一
 ### 我想创建或加入 SIG
 1. 浏览 [SIG 总览](sigs/) 查看现有 SIG，找到你感兴趣的方向
 2. **加入**：参加 SIG 例会（日历见 [sigs/](sigs/)）并做自我介绍
-3. **创建**新 SIG：阅读 [SIG 创建条件](GOVERNANCE.md#sig-special-interest-group)，然后提交 PR（含 Charter 草案 + 初始成员名单）。TSC 在 2 周内投票决定
-4. 查看 [角色定义](contributors/roles.md) 了解 Chair / Tech Lead / Approver 等角色的职责
+3. **创建**新 SIG：阅读 [SIG 创建条件](GOVERNANCE_CN.md#sig-special-interest-group)，然后提交 PR（含 Charter 草案 + 初始成员名单）。TSC 在 2 周内投票决定
+4. 查看 [角色定义](contributors/roles_CN.md) 了解 Chair / Tech Lead / Approver 等角色的职责
 
 ### 我有问题或想讨论某个话题
 加入我们的任何[交流渠道](#交流渠道)提问！我们有一个热心的社区随时准备帮助。

--- a/contributors/CONTRIBUTING.md
+++ b/contributors/CONTRIBUTING.md
@@ -368,7 +368,7 @@ Code review is key to maintaining FlagOS quality. See the [Code Review Guide](re
 ### Communication Channels
 
 - **Email**: contact@flagos.io
-- **WeChat Official Account**: FlagOpen
+- **WeChat Official Account**: 智源FlagOpen
 - **GitHub Discussions**: [FlagOS Community](https://github.com/FlagOS-AI/community/discussions)
 - **GitHub Issues**: Use for bugs and feature requests
 

--- a/contributors/CONTRIBUTING_CN.md
+++ b/contributors/CONTRIBUTING_CN.md
@@ -304,9 +304,9 @@ feat: 为 FlagAttention 实现新的注意力算子
 ### 交流渠道
 
 - **邮箱**: contact@flagos.io
-- **微信公众号**: FlagOpen
-- **微信视频号**: FlagOpen
-- **GitHub Discussions**: [即将推出]
+- **微信公众号**: 智源FlagOpen
+- **微信视频号**: 智源FlagOpen
+- **GitHub Discussions**: [flagos-ai/community/discussions](https://github.com/flagos-ai/community/discussions)
 - **GitHub Issues**: 用于 bug 和功能请求
 
 ### 参与讨论
@@ -328,8 +328,8 @@ feat: 为 FlagAttention 实现新的注意力算子
 
 我们致力于提供热情和包容的社区。所有贡献者必须遵守我们的行为准则：
 
-- **[Code of Conduct (English)](CODE_OF_CONDUCT.md)**
-- **[行为准则 (中文)](CODE_OF_CONDUCT_CN.md)**
+- **[Code of Conduct (English)](../CODE_OF_CONDUCT.md)**
+- **[行为准则 (中文)](../CODE_OF_CONDUCT_CN.md)**
 
 不可接受的行为包括骚扰、歧视和违反这些标准。
 
@@ -356,7 +356,7 @@ feat: 为 FlagAttention 实现新的注意力算子
 - [FlagOS 组织](https://github.com/flagos-ai)
 - [FlagOS Wiki](https://flagos-wiki.baai.ac.cn/)
 - [行为准则](../CODE_OF_CONDUCT_CN.md)
-- [社区 README](README_CN.md)
+- [社区 README](../README_CN.md)
 
 ---
 

--- a/contributors/faq.md
+++ b/contributors/faq.md
@@ -43,7 +43,7 @@ See sig-chip's CI tier requirements. At minimum, the runner must be able to comp
 ### Q: How do I contact the FlagOS team?
 - GitHub Discussions: [FlagOS Community](https://github.com/FlagOS-AI/community/discussions)
 - Email: contact@flagos.io
-- WeChat Official Account: FlagOpen
+- WeChat Official Account: 智源FlagOpen
 
 ### Q: I can't find the answer to my question?
 Ask in the Q&A category of GitHub Discussions.

--- a/fep/README.md
+++ b/fep/README.md
@@ -84,7 +84,7 @@ Provisional ──→ Implementable ──→ Implemented
 | **Implementable** | Design approved, ready to implement | SIG approvers approve PR, then merge |
 | **Implemented** | Code merged, acceptance criteria met | Update doc via PR |
 | **Deferred** | Postponed to a later release | Move to next Milestone |
-| **Rejected** | Not moving forward | Close PR; rejected FEPs should still be merged to preserve the decision record |
+| **Rejected** | Not moving forward | Merge the PR with Status `Rejected` to preserve the decision record |
 
 > Status is marked in the FEP doc as `**Status:** <value>` and updated via follow-up PRs at each state transition.
 

--- a/fep/README_CN.md
+++ b/fep/README_CN.md
@@ -82,7 +82,7 @@ Provisional ──→ Implementable ──→ Implemented
 | **Implementable** | 设计已批准，可开始实现 | SIG Approver 批准 PR 后合入 |
 | **Implemented** | 代码已合入，验收标准已满足 | 通过 PR 更新文档 |
 | **Deferred** | 推迟到后续版本 | 移至下一 Milestone |
-| **Rejected** | 不再推进 | 关闭 PR；被拒绝的 FEP 仍应合入以保留决策记录 |
+| **Rejected** | 不再推进 | 将 Status 标为 `Rejected` 后合入 PR,以保留决策记录 |
 
 > 状态在 FEP 文档中标注为 `**Status:** <value>`，每次状态变更通过后续 PR 更新。
 

--- a/release/README.md
+++ b/release/README.md
@@ -132,7 +132,7 @@ FlagOS vX.Y Release Calendar
 
 ### Per Validation Iteration (.postN)
 
-1. RM tags all modules with `.postN` using [manage-release.py](manage-release.py)
+1. RM tags all modules with `.postN` using [manage-release.py](tools/manage-release.py)
 2. Update the `version` field in `release-2.1-rc2.yaml`
 3. Run full multi-chip CI test suite
 4. Record blocking issues in the RC tracking Issue
@@ -392,6 +392,6 @@ Thanks to the following contributors who submitted these fixes:
 
 | Tool | Purpose | Path |
 |------|------|------|
-| `manage-release.py` | Automated branch creation and tagging | [manage-release.py](manage-release.py) |
-| `release-2.1-rc2.yaml` | Module manifest and version pinning example (vcstool format) | [release-2.1-rc2.yaml](release-2.1-rc2.yaml) |
-| `chip-targets-2.1-rc2.toml` | Chip SDK version and Docker base image example | [chip-targets-2.1-rc2.toml](chip-targets-2.1-rc2.toml) |
+| `manage-release.py` | Automated branch creation and tagging | [manage-release.py](tools/manage-release.py) |
+| `release-2.1-rc2.yaml` | Module manifest and version pinning example (vcstool format) | [release-2.1-rc2.yaml](2.1/release-2.1-rc2.yaml) |
+| `chip-targets-2.1-rc2.toml` | Chip SDK version and Docker base image example | [chip-targets-2.1-rc2.toml](2.1/chip-targets-2.1-rc2.toml) |

--- a/release/README_CN.md
+++ b/release/README_CN.md
@@ -132,7 +132,7 @@ FlagOS vX.Y 发布日历
 
 ### 每个验证轮次 (.postN)
 
-1. RM 按 [manage-release.py](manage-release.py) 为所有模块打 `.postN` tag
+1. RM 按 [manage-release.py](tools/manage-release.py) 为所有模块打 `.postN` tag
 2. 更新 `release-2.1-rc2.yaml` 中的 `version` 字段
 3. 多芯片 CI 跑全量测试
 4. 记录阻塞问题到 RC 追踪 Issue
@@ -392,6 +392,6 @@ YYYY-MM-DD
 
 | 工具 | 用途 | 路径 |
 |------|------|------|
-| `manage-release.py` | 自动化分支创建与打 tag | [manage-release.py](manage-release.py) |
-| `release-2.1-rc2.yaml` | 模块清单与版本锁定示例（vcstool 格式） | [release-2.1-rc2.yaml](release-2.1-rc2.yaml) |
-| `chip-targets-2.1-rc2.toml` | 芯片 SDK 版本与 Docker 基础镜像示例 | [chip-targets-2.1-rc2.toml](chip-targets-2.1-rc2.toml) |
+| `manage-release.py` | 自动化分支创建与打 tag | [manage-release.py](tools/manage-release.py) |
+| `release-2.1-rc2.yaml` | 模块清单与版本锁定示例（vcstool 格式） | [release-2.1-rc2.yaml](2.1/release-2.1-rc2.yaml) |
+| `chip-targets-2.1-rc2.toml` | 芯片 SDK 版本与 Docker 基础镜像示例 | [chip-targets-2.1-rc2.toml](2.1/chip-targets-2.1-rc2.toml) |

--- a/sigs/README.md
+++ b/sigs/README.md
@@ -63,7 +63,7 @@ After TSC approves a new SIG, the Chair must complete the following within **2 w
 - [ ] Publish the agenda before the first meeting (per the [Meeting Operations Guide](../contributors/meeting-guide.md))
 
 **Community Participation**
-- [ ] Chair and tech leads read the [Moderation Guidelines](../contributors/communication-guidelines.md#8-moderation)
+- [ ] Chair and tech leads read the [Moderation Guidelines](../contributors/communication-guidelines.md#viii-moderation)
 - [ ] Give a SIG introduction at the next community all-hands (5-minute lightning talk)
 - [ ] Submit the first monthly brief to TSC (1 page, including meeting notes link and key progress)
 


### PR DESCRIPTION
Repo-wide link and consistency pass, by user scenario:

**Broken relative links** (found with a link checker):
- `release/README(_CN).md`: `manage-release.py`, `release-2.1-rc2.yaml`, `chip-targets-2.1-rc2.toml` still pointed at `release/` root after #46 moved them into `tools/` and `2.1/`.
- `contributors/CONTRIBUTING_CN.md`: CoC and community-README links missing the `../` prefix (targets live at repo root).
- `sigs/README.md`: Moderation anchor was `#8-moderation` but the heading is `## VIII. Moderation`.

**Stale placeholders**:
- GitHub Discussions is enabled on this repo and several docs already link to it, yet the root READMEs and CN contributing guide still said "Coming Soon / 即将推出". Now linked.
- WeChat official account name unified to 智源FlagOpen (three docs said "FlagOpen", root READMEs say 智源FlagOpen).

**Contradiction fix** — Rejected FEP handling:
- `fep/README(_CN).md` lifecycle table said "Close PR; rejected FEPs should still be merged" — closing and merging are mutually exclusive, and the authoring guide/FAQ both say rejected FEPs are merged to preserve the decision record. Reworded to "merge with Status `Rejected`".

**CN reader routing** (`README_CN.md`):
- Community Navigation, SIG-creation and role links now point at `GOVERNANCE_CN.md` / `roles_CN.md` instead of the English versions (CN targets exist).