### PR TITLE
ci: fix release workflow paths after release/ reorg; drop daily schedule

### DIFF
--- a/.github/workflows/release-branch-tag.yml
+++ b/.github/workflows/release-branch-tag.yml
@@ -1,19 +1,17 @@
 name: Release Branch & Tag
 
 on:
-  schedule:
-    # 每天北京时间 04:00 (UTC 20:00)
-    - cron: '0 20 * * *'
   workflow_dispatch:
     inputs:
       manifest:
-        description: 'release YAML 文件名'
+        description: 'release YAML 清单路径（相对 release/）'
         required: true
-        default: 'release-2.1-rc2.yaml'
+        default: '2.1/release-2.1-rc2.yaml'
         type: choice
         options:
-          - release-2.1-rc0.yaml
-          - release-2.1-rc2.yaml
+          - 2.1/release-2.1-rc0.yaml
+          - 2.1/release-2.1-rc2.yaml
+          - 2.1/release-2.1.yaml
       dry_run:
         description: '预览模式（不实际操作）'
         required: false
@@ -49,11 +47,11 @@ jobs:
           FLAGOS_PAT: ${{ secrets.FLAGOS_PAT }}
         working-directory: release
         run: |
-          MANIFEST="${{ inputs.manifest || 'release-2.1-rc2.yaml' }}"
+          MANIFEST="${{ inputs.manifest }}"
           DRY_RUN="${{ inputs.dry_run || false }}"
 
           if [ "$DRY_RUN" = "true" ]; then
-            python3 manage-release.py --dry-run "$MANIFEST"
+            python3 tools/manage-release.py --dry-run "$MANIFEST"
           else
-            python3 manage-release.py --workdir /tmp/flagos-release "$MANIFEST"
+            python3 tools/manage-release.py --workdir /tmp/flagos-release "$MANIFEST"
           fi


### PR DESCRIPTION
The **Release Branch & Tag** workflow has failed every night since 2026-07-05:

```
python3: can't open file '.../release/manage-release.py': [Errno 2] No such file or directory
```

PR #46 moved `manage-release.py` to `release/tools/` and the 2.1 manifests to `release/2.1/`, but the workflow still referenced the old flat paths. Fixes:

- Script path → `tools/manage-release.py`; manifest choices → `2.1/...` (also added the GA `release-2.1.yaml`).
- **Removed the daily cron schedule.** FlagOS 2.1 is released — re-tagging the rc2 manifest nightly is a no-op at best and a stray-tag risk at worst. Branch/tag creation is an RM action tied to release events, so `workflow_dispatch` (with dry-run) fits the process better. When 2.2 reaches RC, add its manifest to the choice list.

Nightly failure emails stop once this merges.