### PR TITLE
docs: align FEP authoring guidance with template and ownership model

### DIFF
--- a/contributors/fep-guide.md
+++ b/contributors/fep-guide.md
@@ -29,9 +29,12 @@ Locate the SIG that corresponds to the module(s) involved in your proposal:
 | FlagPerf | [sig-benchmark](../sigs/_planned/sig-benchmark.md) | Planned |
 | FlagRelease | [sig-tools](../sigs/_planned/sig-tools.md) | Planned |
 | Skills | [sig-agent](../sigs/_planned/sig-agent.md) | Planned |
+| Edge hardware | [sig-edge](../sigs/_planned/sig-edge.md) | Planned |
+| OS packaging / distribution integration (openKylin, openEuler) | [sig-os](../sigs/_planned/sig-os.md) | Planned |
+| Experimental RISC-V support | [sig-riscv](../sigs/_planned/sig-riscv.md) | Planned |
 | FlagQuantum | [wg-ai4s](../wg/wg-ai4s/) | Incubating |
 | FlagOS-Robo | [wg-embodied](../wg/wg-embodied/) | Incubating |
-| Crosses multiple SIGs or none of the above | Home SIG assigned by TSC | — |
+| Crosses multiple SIGs or none of the above | Home SIG assigned by TSC ([sig-architecture](../sigs/_planned/sig-architecture.md) during bootstrap) | — |
 
 > SIGs/WGs marked "Planned" or "Incubating" have no Approver yet. FEPs for these modules are approved directly by the TSC.
 
@@ -49,15 +52,15 @@ Ways to do this:
 ## Step 3: Write the FEP Document
 
 1. Copy the [FEP template](../fep/fep-template/README.md) to `fep/sig-xxx/title-slug.md`
-2. Fill in at minimum: Summary + Motivation + Goals + Test Plan
+2. Fill in at minimum the template's **(Required)** sections: Summary + Goals + Packaging + Test Plan
 3. Set the initial Status to `Provisional`
-4. Title format: `NNNN-title-slug.md` (NNNN = PR number)
+4. Name the file `title-slug.md` for now — rename it to `NNNN-title-slug.md` (NNNN = PR number) after the PR is created, before merge
 
 ## Step 4: Open a PR
 
 1. Open a Draft PR (if further discussion is needed) or a regular PR (if already well-discussed)
 2. The PR title should describe the feature; the PR description can be brief — the FEP document itself carries the details
-3. Link the PR to the corresponding Milestone
+3. To target a release, set `Target Version: FlagOS X.Y` in the FEP header — the Release Manager then attaches the PR to the corresponding Milestone (mind the [FEP Freeze date](../release/2.2/schedule.md))
 
 ## Step 5: Drive the Approval
 

--- a/fep/README.md
+++ b/fep/README.md
@@ -104,7 +104,7 @@ in the problem space and willingness to review.
 Copy the [FEP template](fep-template/README.md) to `fep/sig-xxx/title-slug.md`.
 
 - `title-slug` is a short hyphenated English description
-- Minimum content to start: Summary + Motivation. Everything else can follow later.
+- Minimum content to start: the template's **(Required)** sections — Summary, Goals, Packaging, Test Plan. Everything else can follow later.
 - Set initial Status to `Provisional`
 
 ### 2. Open a PR

--- a/fep/README_CN.md
+++ b/fep/README_CN.md
@@ -99,7 +99,7 @@ Provisional ──→ Implementable ──→ Implemented
 将 [FEP 模板](fep-template/README.md) 复制到 `fep/sig-xxx/title-slug.md`。
 
 - `title-slug` 是一个简短的英文连字符描述
-- 起步最小内容：Summary + Motivation，其余后续补充
+- 起步最小内容：模板中标注 **(Required)** 的章节——Summary、Goals、Packaging、Test Plan，其余后续补充
 - 初始 Status 设为 `Provisional`
 
 ### 2. 提交 PR


### PR DESCRIPTION
Walking the "Propose a new feature" path from the README role router surfaced three inconsistencies between the authoring surfaces:

**Minimum-content mismatch.** The template marks Summary / Goals / Packaging / Test Plan as **(Required)**, but `fep/README(_CN).md` said the minimum is "Summary + Motivation" and `contributors/fep-guide.md` said "Summary + Motivation + Goals + Test Plan". Three surfaces, three answers. All now defer to the template's (Required) markers — and since 2.2 makes an executable Test Plan a hard gate for `Implementable`, telling authors "Summary + Motivation is enough to start" was setting them up for a late surprise.

**File-naming contradiction in the authoring guide.** Step 3 said "Title format: `NNNN-title-slug.md` (NNNN = PR number)" — impossible before the PR exists; the process (fep/README "File Naming") is slug first, rename after the PR number is known. The guide now says exactly that.

**Milestone step contradicted the ownership model.** Step 4 told authors to "link the PR to the corresponding Milestone" — authors can't set milestones, and per process the Owner declares `Target Version` in the FEP header while the Release Manager attaches the milestone. Reworded to match (and to point at the freeze date).

Also completed the fep-guide SIG routing table: `sig-edge`, `sig-os`, `sig-riscv`, `sig-architecture` were missing even though all have charter drafts, existing FEP directories (0015, 0019, 0034), and are listed in fep/README's Planned table.