### PR TITLE
docs(incubator): drop per-file governing-language notices

### DIFF
--- a/incubator/acceptance-runbook.md
+++ b/incubator/acceptance-runbook.md
@@ -2,8 +2,6 @@
 
 [English](acceptance-runbook.md) | [中文](acceptance-runbook_CN.md)
 
-> The English version is authoritative. The Chinese translation is provided for convenience; if the versions differ, the English version prevails.
-
 > Operational runbook for step ⑤ of the donation process in Section 6 of the [README](README.md): after Final Acceptance is recorded, the execution team completes asset migration and announcements per this document.
 
 ## 0. Preconditions

--- a/incubator/acceptance-runbook_CN.md
+++ b/incubator/acceptance-runbook_CN.md
@@ -2,8 +2,6 @@
 
 [English](acceptance-runbook.md) | [中文](acceptance-runbook_CN.md)
 
-> 本文档以英文版本为准，中文版本供阅读便利；如两者存在不一致，以英文版本为准。
-
 > 本文件是 [README_CN.md](README_CN.md) 第 6 节流程第 ⑤ 步的操作手册：Final Acceptance 记录生效后，执行团队按此完成资产迁移与对外发布。
 
 ## 0. 前置条件

--- a/incubator/archiving-runbook.md
+++ b/incubator/archiving-runbook.md
@@ -2,8 +2,6 @@
 
 [English](archiving-runbook.md) | [中文](archiving-runbook_CN.md)
 
-> The English version is authoritative. The Chinese translation is provided for convenience; if the versions differ, the English version prevails.
-
 > Runbook for executing an archiving decision under Section 8 of the [README](README.md). Archiving is a neutral exit; keep all wording non-punitive.
 
 ## 1. Notice Period

--- a/incubator/archiving-runbook_CN.md
+++ b/incubator/archiving-runbook_CN.md
@@ -2,8 +2,6 @@
 
 [English](archiving-runbook.md) | [中文](archiving-runbook_CN.md)
 
-> 本文档以英文版本为准，中文版本供阅读便利；如两者存在不一致，以英文版本为准。
-
 > [README_CN.md](README_CN.md) 第 8 节归档决议通过后的执行手册。归档是中性退出，执行时注意措辞不带惩罚色彩。
 
 ## 1. 通知期

--- a/incubator/license-policy.md
+++ b/incubator/license-policy.md
@@ -2,8 +2,6 @@
 
 [English](license-policy.md) | [中文](license-policy_CN.md)
 
-> The English version is authoritative. The Chinese translation is provided for convenience; if the versions differ, the English version prevails.
-
 > This document details the license policy in Section 9 of the [README](README.md), applying to all incubating and graduated projects.
 
 ## 1. Outbound License

--- a/incubator/license-policy_CN.md
+++ b/incubator/license-policy_CN.md
@@ -2,8 +2,6 @@
 
 [English](license-policy.md) | [中文](license-policy_CN.md)
 
-> 本文档以英文版本为准，中文版本供阅读便利；如两者存在不一致，以英文版本为准。
-
 > 本文件是 [README_CN.md](README_CN.md) 第 9 节许可证政策的实施细则，适用于所有孵化中与正式项目。
 
 ## 1. 出口许可证

--- a/incubator/mentor-guide.md
+++ b/incubator/mentor-guide.md
@@ -2,8 +2,6 @@
 
 [English](mentor-guide.md) | [中文](mentor-guide_CN.md)
 
-> The English version is authoritative. The Chinese translation is provided for convenience; if the versions differ, the English version prevails.
-
 > This document details how Mentors are appointed and what they do, per Section 7 of the [README](README.md).
 
 ## 1. Who Mentors Are

--- a/incubator/mentor-guide_CN.md
+++ b/incubator/mentor-guide_CN.md
@@ -2,8 +2,6 @@
 
 [English](mentor-guide.md) | [中文](mentor-guide_CN.md)
 
-> 本文档以英文版本为准，中文版本供阅读便利；如两者存在不一致，以英文版本为准。
-
 > 本文件说明孵化项目 Mentor 的产生、职责与工作方式，是 [README_CN.md](README_CN.md) 第 7 节的实施细则。
 
 ## 1. Mentor 是谁

--- a/incubator/security-policy.md
+++ b/incubator/security-policy.md
@@ -2,8 +2,6 @@
 
 [English](security-policy.md) | [中文](security-policy_CN.md)
 
-> The English version is authoritative. The Chinese translation is provided for convenience; if the versions differ, the English version prevails.
-
 > This document details the security-response policy in Section 9 of the [README](README.md), applying to all incubating and graduated projects.
 
 ## 1. Reporting Channel

--- a/incubator/security-policy_CN.md
+++ b/incubator/security-policy_CN.md
@@ -2,8 +2,6 @@
 
 [English](security-policy.md) | [中文](security-policy_CN.md)
 
-> 本文档以英文版本为准，中文版本供阅读便利；如两者存在不一致，以英文版本为准。
-
 > 本文件是 [README_CN.md](README_CN.md) 第 9 节安全响应的实施细则，适用于所有孵化中与正式项目。
 
 ## 1. 报告渠道


### PR DESCRIPTION
按维护者意见，去掉五对政策/手册文件（10 个文件）头部逐份重复的语言效力声明（"The English version is authoritative..." / "本文档以英文版本为准..."）。

语言规则的**唯一规范出处**保留在两份 README 第 1 节的 Language 段：英文为工作语言、政策以英文版为准、档案英文填写、法律文件自定语言条款、修改须同 PR 更新双版本。sga-outline.md 的双语例外说明性质不同（解释该文件为何是双语单文件），一并保留。

纯删除，无内容变更：10 files changed, 20 deletions.