### PR TITLE
docs(incubator): split Name/ID column and allow MAINTAINERS-file link

### DIFF
--- a/incubator/proposal-template.md
+++ b/incubator/proposal-template.md
@@ -1,26 +1,43 @@
 # Contribution Proposal: <Project Name>
 
 <!--
-Copy this template to incubator/projects/<project-name>/proposal.md and submit as a PR
-(process in /incubator/README.md Section 6; questions to contact@flagos.io).
+HOW TO USE THIS TEMPLATE
 
-Fill in all fields truthfully — especially the "IP Status Disclosure" section.
-Issues disclosed early can be worked out; issues concealed will block acceptance at IP clearance.
-Write "N/A" where a field does not apply; do not delete sections.
+1. Copy this file to incubator/projects/<project-name>/proposal.md and submit as a PR
+   (process: /incubator/README.md Section 6; questions: contact@flagos.io).
+2. Every field has a short hint in <angle brackets> and most have an example in the
+   HTML comment above it. Replace hints with your content; comments may be kept
+   (they do not render) or deleted.
+3. Write "N/A" where a field does not apply; do not delete sections.
+4. Fill in all fields truthfully — especially "IP Status Disclosure". Issues disclosed
+   early can be worked out; issues concealed will block acceptance at IP clearance.
+5. Do NOT put contract scans, identity documents, or account credentials in this
+   public file; your Mentor or legal contact will provide a private channel.
 -->
 
 ## Basic Information
 
+<!-- Example:
+- Project name: FooKit
+- Website: https://fookit.io
+- Current license: MIT
+- Contributing party & signing entity: Foo Technology Co., Ltd. (北京富科技术有限公司)
+- Contact: Zhang San <zhangsan@footech.com>
+-->
+
 - **Project name**:
 - **Website (if any)**:
-- **Current license**:
-- **Contributing party & signing entity**: <full legal name of the organization or individual contributing the project>
+- **Current license**: <the license the project ships under today, e.g. MIT / Apache-2.0>
+- **Contributing party & signing entity**: <full registered legal name of the organization, or the individual's name — this is who will sign the SGA>
 - **Contact**: <name + email>
 
 **Contribution scope (repository list)**:
 
-<!-- List every repository transferred in this contribution; multi-repo projects list all.
-     Repositories not listed are out of scope. -->
+<!-- List EVERY repository transferred in this contribution; multi-repo projects list all.
+     Repositories not listed are out of scope of the SGA. Example:
+     | https://github.com/footech/fookit      | Core library    |
+     | https://github.com/footech/fookit-docs | Documentation   |
+-->
 
 | Repository | Description |
 |------------|-------------|
@@ -28,51 +45,58 @@ Write "N/A" where a field does not apply; do not delete sections.
 
 ## Project Description
 
-<!-- Start with a single-sentence summary — it will be reused in the acceptance
+<!-- Start with a single sentence — it will be reused verbatim in the acceptance
      announcement and the incubator project list. Then one paragraph: what the project
-     does, what problem it solves, who the target users are. -->
+     does, what problem it solves, who the target users are. Example opening:
+     "FooKit is a kernel autotuning toolkit for heterogeneous AI accelerators." -->
 
 **Relationship to existing FlagOS projects**:
 <!-- Complementary or overlapping with FlagGems / FlagTree / FlagScale / FlagCX / FlagPerf?
-     If overlapping, how is it positioned? (Acceptance principle #6) -->
+     If overlapping, how is it positioned? (Acceptance principle #6) Example:
+     "Complements FlagGems: FooKit tunes the kernels FlagGems provides; no overlap with
+     the other subprojects." -->
 
 **Fit with the FlagOS mission**:
-<!-- How does the project serve the multi-chip AI system software stack and its ecosystem?
-     (Acceptance principle #1) -->
+<!-- How does the project serve the multi-chip AI system software stack and its
+     ecosystem? (Acceptance principle #1) -->
 
 ## Community Status
 
-- **Core developers & affiliations**: <link to the project's MAINTAINERS file if it carries the same information; otherwise fill in the table below>
+- **Core developers & affiliations**: <link to the project's MAINTAINERS file if it already lists name, GitHub ID, organization and role; otherwise fill in the table below>
+
+<!-- Example row:
+     | Zhang San | @zhangsan | Foo Technology | Maintainer, Release Manager | -->
 
 | Name | GitHub ID | Organization | Role |
 |------|-----------|--------------|------|
 | | | | |
 
-- **Developer independence**: <For an organizational contributing party: how many core developers are salaried by it vs. independent, and what is its commitment if business priorities shift? N/A for an individual contributing party.>
-- **Users & adoption**: <any production usage? citable publicly?>
-- **Release history**: <number of releases, most recent date>
+- **Developer independence**: <organizational contributing party only — how many core developers are salaried by it vs. independent, and what is its commitment if business priorities shift? N/A for an individual contributing party>
+- **Users & adoption**: <known users or production deployments; note which can be cited publicly, e.g. "3 companies in production, 2 citable">
+- **Release history**: <number of releases and the most recent, e.g. "12 releases since 2023-05, latest v2.3.1 on 2026-06-10">
 
 ## IP Status Disclosure
 
-<!-- This section will be verified item by item against /incubator/ip-checklist.md
-     after conditional approval. -->
+<!-- Verified item by item against /incubator/ip-checklist.md after conditional
+     approval. Honest "yes, we have an issue" answers are workable; discoveries during
+     clearance are not. -->
 
-- **Code ownership**: <Is ownership clear? Any outsourced code, prior-employer code, or copied code of unclear origin?>
-- **Software copyright registration**: <registered? under whose name?>
-- **Trademarks & domains**: <registered? by whom? willing to transfer or exclusively license?>
-- **Release channels & account assets**: <current state of PyPI / npm / Docker Hub / social accounts, to be handed over per the [acceptance runbook](/incubator/acceptance-runbook.md)>
+- **Code ownership**: <Is ownership clear? Any outsourced code, prior-employer code, or copied code of unclear origin? e.g. "All code written by employees; one module (src/vendor/) adapted from BSD-licensed upstream, headers retained">
+- **Software copyright registration**: <registered or not; under whose name, e.g. "Registered in 2024 under Foo Technology Co., Ltd.">
+- **Trademarks & domains**: <name/logo registered? by whom? willing to transfer or exclusively license? e.g. "'FooKit' word mark registered by Foo Technology; willing to transfer">
+- **Release channels & account assets**: <current state of PyPI / npm / Docker Hub / social accounts; handover happens after acceptance per the [acceptance runbook](/incubator/acceptance-runbook.md)>
 - **Known risks**: <GPL-family dependencies, cryptographic functionality (export compliance), patent issues, ongoing disputes; write "none" if none>
 
 **AI artifacts (if applicable)**:
 
-- **Model weights**: <contributed along with code? intended license?>
-- **Datasets**: <provenance and licenses of training/eval datasets; redistributable?>
+- **Model weights**: <contributed along with code? intended license? e.g. "Yes, under Apache-2.0" or "N/A">
+- **Datasets**: <provenance and licenses of training/eval datasets; redistributable? e.g. "Eval set derived from MMLU (MIT), redistributable" or "N/A">
 
 ## Post-Contribution Plan
 
-- **Initial maintainers**:
-- **6–12 month roadmap**: <a few sentences>
-- **Support requested**: <CI resources, promotion, mentoring focus, etc.>
+- **Initial maintainers**: <who will maintain after acceptance — names or "same as core developers table">
+- **6–12 month roadmap**: <a few sentences, e.g. "H2 2026: v3.0 with X; H1 2027: support for Y">
+- **Support requested**: <what you need from the community — CI resources, promotion, mentoring focus, etc.>
 
 ## Commitments
 
@@ -84,7 +108,10 @@ Check to confirm:
 - [ ] Aware of the 12-month conditional-approval validity, the archiving mechanism, and the irrevocable-license terms (README Sections 6 & 8)
 - [ ] Confirm this proposal is truthful with no material omissions
 
-## Proposed Mentors (optional; the TSC will assign)
+## Proposed Mentors
+
+<!-- Optional; leave empty and the TSC will assign. Mentors must not be from the
+     contributing party or its affiliates. -->
 
 -
 

--- a/incubator/proposal-template.md
+++ b/incubator/proposal-template.md
@@ -42,11 +42,11 @@ Write "N/A" where a field does not apply; do not delete sections.
 
 ## Community Status
 
-- **Core developers & affiliations**:
+- **Core developers & affiliations**: <link to the project's MAINTAINERS file if it carries the same information; otherwise fill in the table below>
 
-| Name/ID | Organization | Role |
-|---------|--------------|------|
-| | | |
+| Name | GitHub ID | Organization | Role |
+|------|-----------|--------------|------|
+| | | | |
 
 - **Developer independence**: <For an organizational contributing party: how many core developers are salaried by it vs. independent, and what is its commitment if business priorities shift? N/A for an individual contributing party.>
 - **Users & adoption**: <any production usage? citable publicly?>

--- a/incubator/proposal-template.md
+++ b/incubator/proposal-template.md
@@ -62,13 +62,17 @@ HOW TO USE THIS TEMPLATE
 
 ## Community Status
 
-- **Core developers & affiliations**: <link to the project's MAINTAINERS file if it already lists name, GitHub ID, organization and role; otherwise fill in the table below>
+- **Core developers & affiliations**: <fill in the table below, or link an equivalent MAINTAINERS file pinned to a commit SHA (a mutable branch link does not preserve the roster the TSC evaluated); the live roster may be linked separately>
 
-<!-- Example row:
-     | Zhang San | @zhangsan | Foo Technology | Maintainer, Release Manager | -->
+<!-- GitHub ID and organization are what the review relies on: the ID to verify
+     contribution activity, the organization to assess concentration. A display name
+     is optional — legal identity, where clearance requires it, is verified through the
+     private channel, not this public file. Example row:
+     | Zhang San | @zhangsan | Foo Technology | Maintainer, Release Manager |
+     | | @lisi-dev | Independent | Committer | -->
 
-| Name | GitHub ID | Organization | Role |
-|------|-----------|--------------|------|
+| Name (optional) | GitHub ID | Organization / Independent | Role |
+|-----------------|-----------|---------------------------|------|
 | | | | |
 
 - **Developer independence**: <organizational contributing party only — how many core developers are salaried by it vs. independent, and what is its commitment if business priorities shift? N/A for an individual contributing party>
@@ -78,8 +82,10 @@ HOW TO USE THIS TEMPLATE
 ## IP Status Disclosure
 
 <!-- Verified item by item against /incubator/ip-checklist.md after conditional
-     approval. Honest "yes, we have an issue" answers are workable; discoveries during
-     clearance are not. -->
+     approval. Disclose known issues here. Issues found later during clearance are
+     documented and resolved then (compatible relicensing, retroactive authorization,
+     rewrite, or removal); material omissions or issues left unresolved may block
+     acceptance. -->
 
 - **Code ownership**: <Is ownership clear? Any outsourced code, prior-employer code, or copied code of unclear origin? e.g. "All code written by employees; one module (src/vendor/) adapted from BSD-licensed upstream, headers retained">
 - **Software copyright registration**: <registered or not; under whose name, e.g. "Registered in 2024 under Foo Technology Co., Ltd.">
@@ -89,8 +95,11 @@ HOW TO USE THIS TEMPLATE
 
 **AI artifacts (if applicable)**:
 
-- **Model weights**: <contributed along with code? intended license? e.g. "Yes, under Apache-2.0" or "N/A">
-- **Datasets**: <provenance and licenses of training/eval datasets; redistributable? e.g. "Eval set derived from MMLU (MIT), redistributable" or "N/A">
+<!-- A repository license covers code, not necessarily third-party data or weights
+     inside it — state the license of the artifact itself, verified at its source. -->
+
+- **Model weights**: <contributed along with code? license of the weights themselves, and the base model's terms if fine-tuned? e.g. "Yes, weights under Apache-2.0, trained from scratch" or "N/A">
+- **Datasets**: <provenance and license of the dataset content itself; redistributable? e.g. "Eval set created by Foo Technology, contributed under CC BY 4.0, redistribution rights confirmed" or "N/A">
 
 ## Post-Contribution Plan
 


### PR DESCRIPTION
提案模板的三项优化（本 PR 累计两个 commit）：

## 1. Name/ID 拆列 + MAINTAINERS 链接替代（首个 commit）

- `Name/ID` 斜杠写法有歧义（读作二选一），拆为 `Name | GitHub ID | Organization | Role` 四列：真实姓名用于 IP 清理溯源与 CLA 核对，GitHub ID 用于核实贡献活跃度；
- 仓库已有等效 MAINTAINERS 文件的可贴链接替代填表，避免归档提案与实际名单漂移。

## 2. 与 Apache / CNCF 模板再比对后的定位（本 commit）

- 结构维持精简不动：无新增必填字段，仍比 Apache 模板轻（不要求邮箱/CLA 状态列表、无八节风险自评），比 CNCF issue form 的纯链接式重一档（我们需要 IP 自述与承诺勾选，因为提案即归档档案）；
- 吸收 Apache 的做法：**每节配说明与示例**（"Each section has both commentary/explanation and examples"），全部放 HTML 注释内，渲染与归档后不可见。

## 3. 逐字段填写指引与小示例

- 顶部改为编号式 HOW TO USE（复制路径、N/A 规则、如实披露提示、敏感材料警示——后者原先只在 README，现在模板内也可见）；
- 基本信息、仓库清单、一句话摘要、维护者表格行、IP 自述各项、AI 制品均配 worked example（虚构项目 FooKit）；
- 原先无提示的字段（当前许可证、初始 maintainer、用户采用、发布历史）补充 <角括号提示>；
- Proposed Mentors 注明回避约束（不得来自捐赠方及其关联机构），与 mentor-guide 对齐。

1 file changed；渲染后的正文长度与改前基本一致，指引全部在注释层。