### PR TITLE
Restore Related PRs placeholders in FEP-0062

### DIFF
--- a/fep/sig-framework/0062-verl-hardware-plugin-v0.1.0-multi-chip-grpo-e2e.md
+++ b/fep/sig-framework/0062-verl-hardware-plugin-v0.1.0-multi-chip-grpo-e2e.md
@@ -130,11 +130,11 @@ This FEP moves to `Implemented` once the Cambricon MLU run passes (see the track
 
 ## Related PRs
 
-- [x] [verl-project/verl-hardware-plugin#7](https://github.com/verl-project/verl-hardware-plugin/pull/7) — [Metax] Add metax support
-- [x] [verl-project/verl-hardware-plugin#3](https://github.com/verl-project/verl-hardware-plugin/pull/3) — Add Iluvatar vendor support for verl hardware plugin
-- [x] [verl-project/verl-hardware-plugin#1](https://github.com/verl-project/verl-hardware-plugin/pull/1) — [MLU] feat: add mlu support
-- [x] [verl-project/verl-hardware-plugin#2](https://github.com/verl-project/verl-hardware-plugin/pull/2) — Add FlagOS engines for NVIDIA platform (reference baseline)
-- [x] [verl-project/verl-hardware-plugin#5](https://github.com/verl-project/verl-hardware-plugin/pull/5) — Add e2e check and format check
+<!-- Fill in with actual PR numbers as they land. -->
+
+- [ ] flagos-ai/verl-hardware-plugin#xxx — feat: MetaX platform + FSDP/Megatron engines and GRPO E2E validation
+- [ ] flagos-ai/verl-hardware-plugin#xxx — feat: Iluvatar platform + FSDP/Megatron engines and GRPO E2E validation
+- [ ] flagos-ai/verl-hardware-plugin#xxx — feat: Cambricon MLU platform (CNCL) + FSDP/Megatron engines and GRPO E2E validation
 
 ## Future Plans
 


### PR DESCRIPTION
Reverts the Related PRs section of FEP-0062 back to the author's original placeholder list.

When merging #62 I filled this section with the actual verl-project/verl-hardware-plugin PRs (#1/#2/#3/#5/#7). Per FEP Owner's request, restoring the original placeholders so the Owner fills in the real PR references.

Only the Related PRs section changes; status, acceptance table, and issue #73 link are untouched.