### PR TITLE
docs(fep): codify tracking-issue convention for milestone progress

### DIFF
--- a/contributors/fep-guide.md
+++ b/contributors/fep-guide.md
@@ -60,7 +60,7 @@ Ways to do this:
 
 1. Open a Draft PR (if further discussion is needed) or a regular PR (if already well-discussed)
 2. The PR title should describe the feature; the PR description can be brief — the FEP document itself carries the details
-3. To target a release, set `Target Version: FlagOS X.Y` in the FEP header — the Release Manager then attaches the PR to the corresponding Milestone (mind the [FEP Freeze date](../release/2.2/schedule.md))
+3. To target a release, set `Target Version: FlagOS X.Y` in the FEP header — on merge, a tracking issue (`[FEP-XXXX] <title> tracking`) is created and attached to the corresponding Milestone (mind the [FEP Freeze date](../release/2.2/schedule.md))
 
 ## Step 5: Drive the Approval
 
@@ -73,6 +73,7 @@ Ways to do this:
 
 - Implement the feature in the relevant repos
 - Track implementation PRs in the FEP document's Related PRs section
+- Check off progress in the FEP's tracking issue as items land
 - Once everything is complete, update Status to `Implemented`
 
 ## FEP Status Transitions

--- a/fep/README.md
+++ b/fep/README.md
@@ -131,12 +131,14 @@ impacted by the feature should also review. If no existing SIG fits, use `sig-ar
 
 - Implementation happens across the relevant repos
 - Track related PRs in the `Related PRs` section of the FEP doc
+- Check off progress in the FEP's tracking issue (see [Milestone Usage](#milestone-usage)) as items land
 - Update the FEP doc via follow-up PRs when scope or design changes
 
 ### 5. Wrap Up
 
 - When all acceptance criteria are met, update Status to `Implemented`
 - This is done via a final PR to update the FEP doc
+- Close the FEP's tracking issue — this marks the FEP delivered in the Milestone view
 
 ## File Naming
 
@@ -159,8 +161,9 @@ impacted by the feature should also review. If no existing SIG fits, use `sig-ar
 
 ## Milestone Usage
 
-- Each FlagOS version has a corresponding Milestone (e.g., `FlagOS 2.1`)
-- Milestones have a deadline set
-- FEPs targeting a version are associated with the corresponding Milestone
+- Each FlagOS version has a corresponding Milestone (e.g., `FlagOS 2.1`) with a deadline set
+- Every FEP targeting a release has **one tracking issue** (`[FEP-XXXX] <title> tracking`), created when the FEP merges, assigned to the FEP Owner, and closed when the FEP reaches `Implemented`
+- **The Milestone holds tracking issues (plus the release tracking issue), not FEP PRs** — so milestone open/closed counts reflect real delivery progress
+- Deferring a FEP to a later release moves its tracking issue to the next Milestone; the issue is not closed
 - Release Manager tracks progress via the Milestone view
 - Live status for every release is surfaced at the top of this page under [🚩 Release Tracker](#-release-tracker)

--- a/fep/README_CN.md
+++ b/fep/README_CN.md
@@ -125,12 +125,14 @@ Provisional ──→ Implementable ──→ Implemented
 
 - 在相关仓库中进行实现
 - 在 FEP 文档的 `Related PRs` 章节中追踪相关 PR
+- 实现落地时在 FEP 的 tracking issue（见 [Milestone 使用](#milestone-使用)）中勾选进度
 - 当范围或设计变更时，通过后续 PR 更新 FEP 文档
 
 ### 5. 收尾
 
 - 所有验收标准满足后，将 Status 更新为 `Implemented`
 - 通过最终 PR 更新 FEP 文档
+- 关闭该 FEP 的 tracking issue —— Milestone 视图中即标记为已交付
 
 ## 文件命名
 
@@ -153,8 +155,9 @@ Provisional ──→ Implementable ──→ Implemented
 
 ## Milestone 使用
 
-- 每个 FlagOS 版本对应一个 Milestone（如 `FlagOS 2.1`）
-- Milestone 设有截止日期
-- 目标版本的 FEP 关联到对应的 Milestone
+- 每个 FlagOS 版本对应一个 Milestone（如 `FlagOS 2.1`），设有截止日期
+- 每个进入版本的 FEP 都有**一个 tracking issue**（`[FEP-XXXX] <标题> tracking`）：FEP 合入时创建，assign 给 FEP Owner，FEP 达到 `Implemented` 时关闭
+- **Milestone 只挂 tracking issue（以及版本发布追踪 issue），不挂 FEP PR** —— 这样 milestone 的 open/closed 数量反映真实交付进度
+- FEP 推迟到后续版本时，将其 tracking issue 移至下一 Milestone，issue 不关闭
 - Release Manager 通过 Milestone 视图追踪进度
 - 各版本实时进度展示在本页顶部的 [🚩 版本追踪](#-版本追踪-release-tracker)


### PR DESCRIPTION
Codifies the per-FEP tracking-issue convention (k8s enhancements-style) so milestone progress reflects real delivery:

- **fep/README(_CN) Milestone Usage**: every FEP targeting a release gets one tracking issue (`[FEP-XXXX] <title> tracking`), created on merge, assigned to the Owner, closed at `Implemented`; the milestone holds tracking issues, not FEP PRs; deferral re-milestones the issue instead of closing it.
- **fep/README(_CN) steps 4/5 + fep-guide steps 4/6**: reference the tracking issue during implementation and close it at wrap-up.

Already applied to the 2.2 milestone: closed FEP PRs detached, tracking issues #59 #60 #73 #76 #77 #79 attached, #47 now links to the milestone instead of hand-maintaining a FEP list.