### PR TITLE
FEP(sig-network): FlagCX new features for FlagOS 2.2

### DIFF
--- a/fep/sig-network/0085-flagcx-flagos-2.2-new-features.md
+++ b/fep/sig-network/0085-flagcx-flagos-2.2-new-features.md
@@ -4,7 +4,7 @@
 
 **Created:** 2026-07-30
 
-**Owner:** [TODO: @github-username]
+**Owner:** [@MC952-arch](https://github.com/MC952-arch)
 
 **SIG:** sig-network
 
@@ -14,19 +14,20 @@
 
 ## Summary
 
-**(Required)** This FEP covers the FlagCX features planned for the FlagOS 2.2
+This FEP covers the FlagCX features planned for the FlagOS 2.2
 release cycle, on top of v0.13.0:
 
 1. **Vendor adaptation** — T-Head (PPU) backend support, bringing FlagCX to 13
    supported chip backends; extend the FlagCX Device API adaptor interface to
-   2+ additional domestic chips.
+   2 additional domestic chips (Kunlunxin plus one more vendor).
 2. **PD-disaggregation support and optimization for inference** — run
-   prefill-decode disaggregation for GLM5.2 on T-Head and MetaX platforms with
-   3+% end-to-end gain, building on the P2P Engine introduced in v0.13.0
+   prefill-decode disaggregation for GLM5.2 on the T-Head platform with ≥3%
+   end-to-end gain over the Mooncake TransferEngine baseline, building on the
+   P2P Engine introduced in v0.13.0
    ([FEP-0021](0021-flagcx-v0.13.0-new-features.md)).
 3. **Distributed operators** — AllGather / ReduceScatter and the fused
-   AllGather+GEMM / GEMM+ReduceScatter operators, with intra-node and
-   inter-node performance on par with Triton-distributed.
+   AllGather+GEMM / GEMM+ReduceScatter operators on NVIDIA, benchmarked
+   against torch-native and Triton-distributed.
 
 Repository: https://github.com/flagos-ai/FlagCX
 
@@ -41,34 +42,48 @@ matrix grows to include T-Head and more Device API-capable backends.
 
 ### Goals
 
-**(Required)**
-
 - **G1 (T-Head adaptation):** Support the T-Head PPU backend (device adaptor
   `ppu_cuda_adaptor` + CCL adaptor `ppu_nccl_adaptor`, build flag `USE_PPU=1`),
-  bringing the in-tree chip backend count to 13.
+  bringing the in-tree chip backend count to 13. Merged on `main`
+  (flagos-ai/FlagCX#512); adaptation complete and ready for testing.
 - **G2 (Device API adaptor expansion):** Extend the Device API vendor traits
   interface (`flagcx/adaptor/include/device_api/*_comm_traits.h` /
   `*_platform_traits.h`, currently implemented for NVIDIA, Hygon DU and
-  Sunrise) to at least 2 additional domestic chips.
-  <!-- TODO: name the target vendors and the Device API primitive subset that
-       must pass tests to count as supported. -->
+  Sunrise) to 2 additional domestic chips. First target is Kunlunxin, whose
+  PR is expected around 2026-09-10 with runs on their production line; the
+  second vendor is being lined up with the goal of landing within the 2.2
+  window and carries schedule risk.
+  <!-- TODO: name the second vendor once committed, and the Device API
+       primitive subset that must pass tests to count as supported. -->
 - **G3 (PD disaggregation):** GLM5.2 prefill-decode disaggregation runs
-  end-to-end on T-Head and MetaX platforms using the FlagCX P2P Engine as the
-  KV transfer substrate, with ≥3% end-to-end gain.
-  <!-- TODO: define the ≥3% measurement — metric (throughput/TTFT/goodput),
-       baseline, serving framework and workload profile. -->
+  end-to-end on the T-Head platform using the FlagCX P2P Engine as the KV
+  transfer substrate, with ≥3% end-to-end gain over Mooncake TransferEngine
+  (its default configuration) on the same setup. It currently runs on T-Head
+  at parity with the baseline; the gain comes from the optimization work in
+  this cycle. MetaX is a stretch target: its base platform optimization is
+  not done and GLM does not yet run normally there, so MetaX PD acceptance
+  moves out unless that lands first.
+  <!-- TODO: metric definition for the ≥3% (throughput/TTFT/goodput) and
+       workload profile. -->
 - **G4 (Distributed operators):** Provide AllGather, ReduceScatter,
-  AllGather+GEMM and GEMM+ReduceScatter operators whose intra-node and
-  inter-node performance is on par with Triton-distributed.
-  <!-- TODO: define "on par" — Triton-distributed baseline version, tolerance,
-       message-size range, GPU count and topology, per operator. -->
+  AllGather+GEMM and GEMM+ReduceScatter operators on NVIDIA (they build on
+  the Device API and IR bindings, so vendor scope follows Device API
+  availability). Adaptation is complete on NVIDIA; performance beats
+  torch-native in most scenarios, while parity with Triton-distributed is
+  still being optimized.
+  <!-- TODO: repo/PR pointers for the operator implementation, benchmark
+       tolerance vs. Triton-distributed, message-size range and topology. -->
 
 ### Non-Goals
 
 - Device API CustomAllReduce / IR bindings support on vendors beyond the ones
   named in G2 (tracked per-vendor in future cycles).
-- PD disaggregation on platforms other than T-Head and MetaX in this cycle.
+- PD disaggregation on platforms other than T-Head (and MetaX as a stretch)
+  in this cycle.
 - Fused operators beyond the four listed in G4 (e.g. AlltoAll+GEMM for MoE).
+- Ascend enablement: blocked on a PCI-probe interface issue on the Ascend
+  side; not pursued standalone in this cycle, tracked together with the
+  sglang-plugin Huawei P0 work, which hits the same problem.
 
 ## Proposal
 
@@ -83,13 +98,14 @@ Cambricon (cncl), MetaX (mccl), Moore Threads (musa_mccl), Kunlunxin (xccl),
 AMD (rccl), Hygon (dunccl), TsingMicro (tccl), Enflame (eccl), Sunrise (pccl),
 T-Head (ppu_nccl).
 
-**1b. Device API adaptor interface for 2+ domestic chips.** The Device API
+**1b. Device API adaptor interface for 2 more domestic chips.** The Device API
 (v0.11–v0.13) dispatches device-side communication primitives through
 per-vendor traits (`comm_traits.h` / `platform_traits.h`); today only NVIDIA,
 Hygon DU and Sunrise have vendor traits, with a default fallback. This work
 adds traits implementations (and, where needed, kernel compilation pipeline
-support) for additional domestic chips so they can use Device API-based
-features such as CustomAllReduce.
+support) for Kunlunxin and a second vendor so they can use Device API-based
+features such as CustomAllReduce. Vendor-side adaptation is in progress;
+Kunlunxin's PR is expected around 2026-09-10.
 
 <!-- TODO (design): per target vendor — native primitives vs. default
      fallback; LLVM bitcode path availability; symmetric-window vs. IPC-only
@@ -101,36 +117,35 @@ Builds on the v0.13.0 P2P Engine (one-sided RDMA, vectorized read/write,
 topology-aware NIC selection) and its NIXL integration
 (`plugin/nixl/flagcx_p2p_on_nixl_v1.1.0.patch`). This cycle takes that
 substrate to a production inference scenario: GLM5.2 PD disaggregation on
-T-Head and MetaX.
+T-Head, with 1 prefill + 1 decode instance (8+8 cards) and inter-instance KV
+transfers over the network; the setup runs in containers. Baseline for the
+≥3% gain is Mooncake TransferEngine in its default configuration on the same
+topology. Current state: runs end-to-end on T-Head at roughly baseline
+performance; the optimization work targeting the gain is in progress and is
+prioritized on T-Head. On MetaX, the platform's base optimization is not done
+and GLM does not yet run normally, so MetaX follows later.
 
-<!-- TODO (design):
-     1. Integration path — vLLM KV-transfer connector, NIXL backend, or both;
-        serving framework versions on T-Head / MetaX.
-     2. Gaps on these two platforms (P2P Engine has been validated on
-        NVIDIA / Mthreads / MetaX / Hygon; what does T-Head need).
-     3. Source of the optimization — transfer overlap, NIC selection,
-        noncontiguous KV layout handling, or other. -->
+<!-- TODO (design): source of the optimization — transfer overlap, NIC
+     selection, noncontiguous KV layout handling, or other. -->
 
 ### Feature 3: Distributed Operators
 
 Provide standalone AllGather / ReduceScatter and communication-computation
-fused AllGather+GEMM / GEMM+ReduceScatter operators, benchmarked against
-Triton-distributed, targeting parity intra-node and inter-node.
+fused AllGather+GEMM / GEMM+ReduceScatter operators. They sit on the Device
+API and IR bindings, so this cycle's vendor scope is NVIDIA. Adaptation is
+complete on NVIDIA: most scenarios outperform torch-native; parity with
+Triton-distributed is the optimization target and is not yet reached
+everywhere.
 
 <!-- TODO (design):
-     1. Execution model — device-initiated kernels on the Device API IR
-        bindings, or host-side chunked scheduling overlapping collectives with
-        GEMM launches.
-     2. API surface — C/C++ host API, torch ops (plugin/torch), or
-        Triton-language builtins.
-     3. Vendor scope for this cycle.
-     4. Relationship to Triton-distributed — reuse of kernels/algorithms, or
-        independent implementation with it as benchmark baseline only. -->
+     1. Where the operator code lands (repo/PRs) and the API surface exposed.
+     2. Benchmark protocol vs. torch-native and Triton-distributed —
+        versions, message sizes, GEMM shapes, topology. -->
 
 ## Design Details
 
 <!-- TODO: architecture and data-flow details for Features 1b/2/3, to be
-     filled before Status moves to `Implementable`. -->
+     filled as the per-feature TODOs above are resolved. -->
 
 ## Packaging
 
@@ -166,61 +181,96 @@ make USE_NVIDIA=1 COMPILE_KERNEL=1 -j$(nproc)
 - MPI (multi-process tests): OpenMPI or mpich
 - libibverbs (IBRC P2P adaptor, required for PD disaggregation transfers)
 - Vendor toolkit per backend (CUDA toolkit for NVIDIA, etc.)
-<!-- TODO: T-Head and MetaX toolchain/driver versions for Feature 2;
-     serving-framework version pins. -->
+- PD disaggregation runs use the inference stack's images for the target
+  platform (the same communication library paths are exercised there), so no
+  separate legacy-driver images are required.
+<!-- TODO: T-Head toolchain/driver versions and serving-framework pins for
+     Feature 2. -->
 
 ### Multi-Platform Support
 
 | Feature | Platform scope (this cycle) |
 |---|---|
 | T-Head backend | T-Head PPU |
-| Device API adaptor expansion | [TODO: 2+ named vendors] |
-| PD disaggregation (GLM5.2) | T-Head, MetaX |
-| Distributed operators | [TODO] |
+| Device API adaptor expansion | Kunlunxin + 1 vendor [TODO: name when committed] |
+| PD disaggregation (GLM5.2) | T-Head (MetaX stretch, gated on base optimization) |
+| Distributed operators | NVIDIA |
 
 ## Test Plan
 
-**(Required)** Each goal is verified independently, reusing the existing test
+Each goal is verified independently, reusing the existing test
 infrastructure (`test/perf/host_api`, `test/perf/kv_transfer`,
 `test/perf/device_api`).
+
+Test inputs the development side provides before the testing window starts:
+
+- An official test command document per feature (the CI workflows under
+  `.github/workflows/` — currently running the full suites on NVIDIA, MetaX
+  and Hygon on every code update — serve as the command reference; CI
+  coverage for the remaining vendors is being added separately).
+- A per-vendor API compatibility list for the existing host-API surface, so
+  the test matrix reflects the actual supported set rather than the CI
+  subset. Hygon and MetaX coverage in CI is current; vendors last validated
+  in earlier cycles are re-listed with the driver versions they were
+  validated against.
+
+Scope rule for the 2.2 window: existing features are tested against the 2.1
+release scope (more thoroughly than 2.1); new features are tested only within
+the support scope stated in this FEP.
 
 ### G1: T-Head backend
 
 | Test | Command | Expected result |
 |---|---|---|
 | Build | `make USE_PPU=1 -j$(nproc)` | Library builds without errors |
-| Collectives correctness/perf | `cd test/perf/host_api && make USE_PPU=1`, run perf binaries via mpirun on a T-Head node <!-- TODO: binary list, rank count, expected bandwidth --> | All collectives pass correctness check |
+| Collectives correctness/perf | `cd test/perf/host_api && make USE_PPU=1`, run the per-collective binaries (`test_allreduce`, `test_allgather`, `test_reducescatter`, `test_alltoall`, `test_sendrecv`, ...) via mpirun on a T-Head node <!-- TODO: rank count, expected bandwidth --> | All collectives pass correctness check |
 
 ### G2: Device API adaptor expansion
 
-<!-- TODO: per new vendor — build flag, required Device API test binaries
-     (test/device_api unit tests, perf_allreduce_intranode, ...), hardware. -->
+Kunlunxin first (PR expected ~2026-09-10), second vendor when its adaptation
+lands.
 
-### G3: PD disaggregation (GLM5.2 on T-Head / MetaX)
+<!-- TODO: per new vendor — build flag, required Device API test binaries
+     (test/device_api unit tests, test_allreduce_intranode, ...), hardware. -->
+
+### G3: PD disaggregation (GLM5.2 on T-Head)
 
 Acceptance runs on vendor hardware; results (environment, logs, metrics) are
-attached to the tracking issue by the testing party.
+attached to the tracking issue by the testing party. Topology: 1P+1D, 8+8
+cards, KV transfers over the network, containerized.
 
 | Test | Command | Expected result |
 |---|---|---|
-| KV transfer micro-benchmark | `test/perf/kv_transfer/kv_transfer_benchmark.py` on the target platform <!-- TODO: args, expected bandwidth --> | Transfer bandwidth within expected range |
-| E2E PD disaggregation | <!-- TODO: prefill/decode instance launch commands, workload driver, metric collection --> | GLM5.2 serves correctly in PD mode on T-Head and MetaX; ≥3% gain in [TODO: metric] vs. [TODO: baseline] |
+| KV transfer micro-benchmark | `test/perf/kv_transfer/kv_transfer_benchmark.py` on the target platform (connector modes per its README) <!-- TODO: args, expected bandwidth --> | Transfer bandwidth within expected range |
+| E2E PD disaggregation | <!-- TODO: prefill/decode instance launch commands, workload driver, metric collection --> | GLM5.2 serves correctly in PD mode on T-Head; ≥3% gain in [TODO: metric] vs. Mooncake TransferEngine (default) on the same setup |
 
-### G4: Distributed operators vs. Triton-distributed
+### G4: Distributed operators
 
-Baseline: Triton-distributed [TODO: version/commit], same hardware, same
-message sizes.
+Baselines: torch-native collectives+GEMM, and Triton-distributed
+[TODO: version/commit], same hardware, same message sizes. NVIDIA only this
+cycle.
 
 | Test | Command | Expected result |
 |---|---|---|
-| AllGather / ReduceScatter | <!-- TODO: benchmark command --> | Within [TODO: tolerance] of baseline, intra- and inter-node |
-| AllGather+GEMM / GEMM+ReduceScatter | <!-- TODO: benchmark command, GEMM shapes --> | Within [TODO: tolerance] of baseline, intra- and inter-node |
+| AllGather / ReduceScatter | <!-- TODO: benchmark command --> | Outperforms torch-native in the covered scenarios; gap to Triton-distributed recorded per message size |
+| AllGather+GEMM / GEMM+ReduceScatter | <!-- TODO: benchmark command, GEMM shapes --> | Outperforms torch-native in the covered scenarios; gap to Triton-distributed recorded per shape |
 
 ## Related PRs
 
 - [x] flagos-ai/FlagCX#512 — [PAL] Add PPU support (T-Head backend)
+- [x] flagos-ai/FlagCX#539 — [UIL] Add Unified IR support (Device API / IR
+  groundwork Features 1b and 3 build on)
+- [x] flagos-ai/FlagCX#545 — [UIL] Fix multi-backend issues for Unified IR
+- [ ] Kunlunxin Device API traits PR (expected ~2026-09-10)
+- [ ] Second Device API vendor PR [TODO]
 
 ## Implementation History
 
 - 2026-07-30: FEP created as `Provisional` for the FlagOS 2.2 cycle; Features
   2 and 3 under design, Feature 1a merged on main.
+- 2026-08-24: Progress sync with development — T-Head adaptation complete and
+  testable; distributed operators adapted on NVIDIA; PD disaggregation runs
+  on T-Head with optimization in progress (baseline Mooncake); Kunlunxin
+  Device API PR expected ~09-10; MetaX PD moved to stretch (base platform
+  optimization pending); Ascend deferred behind the sglang-plugin Huawei P0.
+- 2026-08-25: FEP updated to the synced scope; Owner set.

--- a/fep/sig-network/0085-flagcx-flagos-2.2-new-features.md
+++ b/fep/sig-network/0085-flagcx-flagos-2.2-new-features.md
@@ -21,12 +21,13 @@ release cycle, on top of v0.13.0:
    supported chip backends; extend the FlagCX Device API adaptor interface to
    2 additional domestic chips (Kunlunxin plus one more vendor).
 2. **PD-disaggregation support and optimization for inference** — run
-   prefill-decode disaggregation for GLM5.2 on the T-Head platform with ≥3%
+   prefill-decode disaggregation for GLM5.2 on T-Head and MetaX with ≥3%
    end-to-end gain over the Mooncake TransferEngine baseline, building on the
    P2P Engine introduced in v0.13.0
    ([FEP-0021](0021-flagcx-v0.13.0-new-features.md)).
-3. **Distributed operators** — fused AllGather+GEMM and GEMM+AllReduce
-   operators (FlagTree) on NVIDIA, benchmarked against torch-native.
+3. **Distributed operators** — AllGather and ReduceScatter, plus the fused
+   AllGather+GEMM and GEMM+ReduceScatter operators, targeting intra-node and
+   inter-node performance on par with Triton-distributed.
 
 Repository: https://github.com/flagos-ai/FlagCX
 
@@ -55,35 +56,38 @@ matrix grows to include T-Head and more Device API-capable backends.
   <!-- TODO: name the second vendor once committed, and the Device API
        primitive subset that must pass tests to count as supported. -->
 - **G3 (PD disaggregation):** GLM5.2 prefill-decode disaggregation runs
-  end-to-end on the T-Head platform using the FlagCX P2P Engine as the KV
+  end-to-end on T-Head and MetaX using the FlagCX P2P Engine as the KV
   transfer substrate, with ≥3% end-to-end gain over Mooncake TransferEngine
-  (its default configuration) on the same setup. It currently runs on T-Head
-  at parity with the baseline; the gain comes from the optimization work in
-  this cycle. MetaX is a stretch target: its base platform optimization is
-  not done and GLM does not yet run normally there, so MetaX PD acceptance
-  moves out unless that lands first.
+  (its default configuration) on the same setup.
+  Status 2026-08-24: runs on T-Head at parity with the baseline, with the
+  optimization work for the gain in progress and prioritized there. MetaX
+  is gated on the platform's base optimization, which is not done — GLM
+  does not yet run normally on MetaX, so its acceptance lands later in the
+  cycle.
   <!-- TODO: metric definition for the ≥3% (throughput/TTFT/goodput) and
        workload profile. -->
-- **G4 (Distributed operators):** Fused AllGather+GEMM and GEMM+AllReduce
-  operators in FlagTree (`python/tutorials/tle/raw/nvshmem/02-allgather-gemm`
-  and `03-gemm-allreduce`) on NVIDIA. Both operators are adapted and tested;
-  benchmark harness (`benchmark.py`) times against torch-native as the
-  baseline and reports speedup. The operators build on FlagCX Device API + IR
-  bindings and NVSHMEM; vendor scope is NVIDIA (sm90+).
-  <!-- TODO: Triton-distributed baseline — whether to add a third variant to
-       benchmark.py or run their upstream benchmark separately, and which
-       version/commit. GEMM+ReduceScatter does not exist in FlagTree as of
-       2026-08-25; confirm whether it ships in this cycle or the FEP scope
-       should reflect the two operators that exist (AG+GEMM, GEMM+AR). -->
+- **G4 (Distributed operators):** AllGather and ReduceScatter, plus the
+  fused AllGather+GEMM and GEMM+ReduceScatter operators, with intra-node
+  and inter-node performance on par with Triton-distributed. The operators
+  build on the FlagCX Device API + IR bindings and NVSHMEM; vendor scope
+  this cycle is NVIDIA (sm90+).
+  Status 2026-08-24: adapted on NVIDIA; most scenarios outperform
+  torch-native, and the gap to Triton-distributed is being optimized. In
+  the FlagTree tree today the fused implementations are
+  `python/tutorials/tle/raw/nvshmem/02-allgather-gemm` (with a benchmark
+  harness against torch-native) and `03-gemm-allreduce`.
+  <!-- TODO: code locations for standalone AllGather / ReduceScatter and
+       GEMM+ReduceScatter (not in the FlagTree tree as of 2026-08-25), and
+       the Triton-distributed comparison method — add a variant to
+       benchmark.py or run their upstream benchmark, and which
+       version/commit defines "on par". -->
 
 ### Non-Goals
 
 - Device API CustomAllReduce / IR bindings support on vendors beyond the ones
   named in G2 (tracked per-vendor in future cycles).
-- PD disaggregation on platforms other than T-Head (and MetaX as a stretch)
-  in this cycle.
-- Fused operators beyond AllGather+GEMM and GEMM+AllReduce (e.g. standalone
-  AllGather/ReduceScatter, GEMM+ReduceScatter, AlltoAll+GEMM for MoE).
+- PD disaggregation on platforms other than T-Head and MetaX in this cycle.
+- Fused operators beyond the four listed in G4 (e.g. AlltoAll+GEMM for MoE).
 - Ascend enablement: blocked on a PCI-probe interface issue on the Ascend
   side; not pursued standalone in this cycle, tracked together with the
   sglang-plugin Huawei P0 work, which hits the same problem.
@@ -120,41 +124,50 @@ Builds on the v0.13.0 P2P Engine (one-sided RDMA, vectorized read/write,
 topology-aware NIC selection) and its NIXL integration
 (`plugin/nixl/flagcx_p2p_on_nixl_v1.1.0.patch`). This cycle takes that
 substrate to a production inference scenario: GLM5.2 PD disaggregation on
-T-Head, with 1 prefill + 1 decode instance (8+8 cards) and inter-instance KV
-transfers over the network; the setup runs in containers. Baseline for the
-≥3% gain is Mooncake TransferEngine in its default configuration on the same
-topology. Current state: runs end-to-end on T-Head at roughly baseline
+T-Head and MetaX, with 1 prefill + 1 decode instance (8+8 cards) and
+inter-instance KV transfers over the network; the setup runs in containers.
+Baseline for the ≥3% gain is Mooncake TransferEngine in its default
+configuration on the same topology.
+
+Status 2026-08-24: runs end-to-end on T-Head at roughly baseline
 performance; the optimization work targeting the gain is in progress and is
-prioritized on T-Head. On MetaX, the platform's base optimization is not done
-and GLM does not yet run normally, so MetaX follows later.
+prioritized on T-Head. MetaX waits on the platform's base optimization —
+GLM does not yet run normally there — so its PD acceptance comes later in
+the cycle.
 
 <!-- TODO (design): source of the optimization — transfer overlap, NIC
      selection, noncontiguous KV layout handling, or other. -->
 
 ### Feature 3: Distributed Operators
 
-Fused AllGather+GEMM and GEMM+AllReduce operators in FlagTree
-(`python/tutorials/tle/raw/nvshmem/02-allgather-gemm` and `03-gemm-allreduce`),
-sm90+ only. Both operators are adapted and tested on NVIDIA with a benchmark
-harness that times against torch-native (separate AG, separate GEMM, and the
-fused path) and reports speedup per layer shape. The operators use FlagCX
-Device API + IR bindings and NVSHMEM for intra-node and inter-node transfers.
+Standalone AllGather / ReduceScatter and fused AllGather+GEMM /
+GEMM+ReduceScatter operators, targeting intra-node and inter-node
+performance on par with Triton-distributed. The operators use the FlagCX
+Device API + IR bindings and NVSHMEM for intra-node and inter-node
+transfers; vendor scope this cycle is NVIDIA (sm90+).
 
-Repository: https://github.com/flagos-ai/FlagTree
+Status 2026-08-24: adapted on NVIDIA, with most scenarios outperforming
+torch-native and the gap to Triton-distributed being optimized. What is in
+the FlagTree tree today (https://github.com/flagos-ai/FlagTree, under
+`python/tutorials/tle/raw/nvshmem/`): `02-allgather-gemm` and
+`03-gemm-allreduce`. The AG+GEMM directory carries a benchmark harness:
+it sweeps seven layer shapes (LLaMA-7B / 3.1-8B / 3.1-70B / 3.1-405B,
+Mistral-7B, Qwen2-72B, GPT-3-175B) at M=8192 (configurable via `--M`),
+fp16 or bf16, gates correctness first (`assert_allclose` at
+`atol=1e-3, rtol=1e-3` per rank), then times six variants — fused total,
+AG-only, GEMM-only, on both the FlagTree and torch sides — and
+`--dump_csv` writes `csv/perf_ag_gemm_<world_size>_ranks.csv` with speedup
+per shape. Run:
+`torchrun --nproc_per_node=<N> benchmark.py --dump_csv` (at least 2 GPUs,
+`WORLD_SIZE % LOCAL_WORLD_SIZE == 0`).
 
-The benchmark sweeps seven layer shapes (LLaMA-7B / 3.1-8B / 3.1-70B / 3.1-405B,
-Mistral-7B, Qwen2-72B, GPT-3-175B) at M=8192 (configurable via `--M`), fp16 or
-bf16. Correctness is gated first (`assert_allclose` at `atol=1e-3, rtol=1e-3`
-per rank before timing), then six timing variants run: fused total, AG-only,
-GEMM-only, on both FlagTree and torch sides. `--dump_csv` writes
-`csv/perf_ag_gemm_<world_size>_ranks.csv` with speedup per shape.
-
-Run: `torchrun --nproc_per_node=<N> benchmark.py --dump_csv` (requires at least
-2 GPUs, `WORLD_SIZE % LOCAL_WORLD_SIZE == 0`).
-
-<!-- TODO: Triton-distributed baseline — whether to add a third variant to
-     benchmark.py or run their upstream benchmark separately, and which
-     version/commit. -->
+<!-- TODO:
+     1. Code locations for standalone AllGather / ReduceScatter and for
+        GEMM+ReduceScatter — neither is in the FlagTree tree as of
+        2026-08-25 (03- is GEMM+AllReduce).
+     2. Triton-distributed comparison method — add a third timing variant
+        to benchmark.py or run their upstream benchmark, and which
+        version/commit defines "on par". -->
 
 ## Design Details
 
@@ -207,7 +220,7 @@ make USE_NVIDIA=1 COMPILE_KERNEL=1 -j$(nproc)
 |---|---|
 | T-Head backend | T-Head PPU |
 | Device API adaptor expansion | Kunlunxin + 1 vendor [TODO: name when committed] |
-| PD disaggregation (GLM5.2) | T-Head (MetaX stretch, gated on base optimization) |
+| PD disaggregation (GLM5.2) | T-Head, MetaX (MetaX gated on its base platform optimization) |
 | Distributed operators | NVIDIA |
 
 ## Test Plan
@@ -247,36 +260,42 @@ lands.
 <!-- TODO: per new vendor — build flag, required Device API test binaries
      (test/device_api unit tests, test_allreduce_intranode, ...), hardware. -->
 
-### G3: PD disaggregation (GLM5.2 on T-Head)
+### G3: PD disaggregation (GLM5.2 on T-Head / MetaX)
 
 Acceptance runs on vendor hardware; results (environment, logs, metrics) are
 attached to the tracking issue by the testing party. Topology: 1P+1D, 8+8
-cards, KV transfers over the network, containerized.
+cards, KV transfers over the network, containerized. T-Head is testable now;
+MetaX follows once its base platform optimization lands and GLM runs there.
 
 | Test | Command | Expected result |
 |---|---|---|
 | KV transfer micro-benchmark | `test/perf/kv_transfer/kv_transfer_benchmark.py` on the target platform (connector modes per its README) <!-- TODO: args, expected bandwidth --> | Transfer bandwidth within expected range |
-| E2E PD disaggregation | <!-- TODO: prefill/decode instance launch commands, workload driver, metric collection --> | GLM5.2 serves correctly in PD mode on T-Head; ≥3% gain in [TODO: metric] vs. Mooncake TransferEngine (default) on the same setup |
+| E2E PD disaggregation | <!-- TODO: prefill/decode instance launch commands, workload driver, metric collection --> | GLM5.2 serves correctly in PD mode; ≥3% gain in [TODO: metric] vs. Mooncake TransferEngine (default) on the same setup |
 
 ### G4: Distributed operators
 
-FlagTree `python/tutorials/tle/raw/nvshmem/02-allgather-gemm` and
-`03-gemm-allreduce`, NVIDIA sm90+ only. Benchmark harness
-(`02-allgather-gemm/benchmark.py`) sweeps seven layer shapes (LLaMA-7B /
+Four operators in scope: AllGather, ReduceScatter, AllGather+GEMM,
+GEMM+ReduceScatter; acceptance target is intra-node and inter-node
+performance on par with Triton-distributed. NVIDIA sm90+ this cycle.
+
+The command below is the harness that exists in the FlagTree tree today
+(`02-allgather-gemm/benchmark.py`): it sweeps seven layer shapes (LLaMA-7B /
 3.1-8B / 3.1-70B / 3.1-405B, Mistral-7B, Qwen2-72B, GPT-3-175B) at M=8192
-(configurable via `--M`), fp16 or bf16. Correctness gated first
+(configurable via `--M`), fp16 or bf16, gates correctness first
 (`assert_allclose` at `atol=1e-3, rtol=1e-3` per rank), then times six
 variants: fused total, AG-only, GEMM-only, on both FlagTree and torch sides.
 
 | Test | Command | Expected result |
 |---|---|---|
-| AllGather+GEMM | `cd python/tutorials/tle/raw/nvshmem/02-allgather-gemm && torchrun --nproc_per_node=<N> benchmark.py --dump_csv` (requires ≥2 GPUs, sm90+, `WORLD_SIZE % LOCAL_WORLD_SIZE == 0`) | Correctness passes per rank; FlagTree fused path outperforms torch-native total latency in the covered shapes; csv written to `csv/perf_ag_gemm_<world_size>_ranks.csv` with speedup column |
+| AllGather+GEMM | `cd python/tutorials/tle/raw/nvshmem/02-allgather-gemm && torchrun --nproc_per_node=<N> benchmark.py --dump_csv` (requires ≥2 GPUs, sm90+, `WORLD_SIZE % LOCAL_WORLD_SIZE == 0`) | Correctness passes per rank; fused path outperforms torch-native total latency in the covered shapes; csv written to `csv/perf_ag_gemm_<world_size>_ranks.csv` with speedup column |
+| GEMM+AllReduce | `03-gemm-allreduce` — test command TBD | Correctness passes; latency vs. torch-native recorded |
+| AllGather / ReduceScatter (standalone) | [TODO: code location and command] | Performance on par with Triton-distributed, intra- and inter-node |
+| GEMM+ReduceScatter | [TODO: code location and command] | Performance on par with Triton-distributed, intra- and inter-node |
 
-GEMM+AllReduce operator exists at `03-gemm-allreduce`; test command TBD.
-
-<!-- TODO: Triton-distributed baseline — whether to add a third timing variant
-     to benchmark.py or run their upstream benchmark separately, which
-     version/commit, and what the acceptance gap is. -->
+<!-- TODO: Triton-distributed comparison method — no baseline exists in the
+     tree today; either add a third timing variant to benchmark.py or run
+     their upstream benchmark, fixing the version/commit and the tolerance
+     that counts as "on par". -->
 
 ## Related PRs
 
@@ -297,3 +316,6 @@ GEMM+AllReduce operator exists at `03-gemm-allreduce`; test command TBD.
   Device API PR expected ~09-10; MetaX PD moved to stretch (base platform
   optimization pending); Ascend deferred behind the sglang-plugin Huawei P0.
 - 2026-08-25: FEP updated to the synced scope; Owner set.
+- 2026-08-25: Goals restored to the development-side feature list (PD on
+  T-Head and MetaX; four distributed operators with the Triton-distributed
+  parity target), with the 08-24 status and the open items kept as TODOs.

--- a/fep/sig-network/0085-flagcx-flagos-2.2-new-features.md
+++ b/fep/sig-network/0085-flagcx-flagos-2.2-new-features.md
@@ -58,24 +58,22 @@ matrix grows to include T-Head and more Device API-capable backends.
 - **G3 (PD disaggregation):** GLM5.2 prefill-decode disaggregation runs
   end-to-end on T-Head and MetaX using the FlagCX P2P Engine as the KV
   transfer substrate, with ≥3% end-to-end gain over Mooncake TransferEngine
-  (its default configuration) on the same setup.
-  Status 2026-08-24: runs on T-Head at parity with the baseline, with the
-  optimization work for the gain in progress and prioritized there. MetaX
-  is gated on the platform's base optimization, which is not done — GLM
-  does not yet run normally on MetaX, so its acceptance lands later in the
-  cycle.
+  (its default configuration) on the same setup. It currently runs on
+  T-Head at parity with the baseline, and the optimization work for the
+  gain is prioritized there. MetaX is gated on the platform's base
+  optimization — GLM does not yet run normally on MetaX, so its acceptance
+  lands later in the cycle.
   <!-- TODO: metric definition for the ≥3% (throughput/TTFT/goodput) and
        workload profile. -->
 - **G4 (Distributed operators):** AllGather and ReduceScatter, plus the
   fused AllGather+GEMM and GEMM+ReduceScatter operators, with intra-node
   and inter-node performance on par with Triton-distributed. The operators
   build on the FlagCX Device API + IR bindings and NVSHMEM; vendor scope
-  this cycle is NVIDIA (sm90+).
-  Status 2026-08-24: adapted on NVIDIA; most scenarios outperform
-  torch-native, and the gap to Triton-distributed is being optimized. In
-  the FlagTree tree today the fused implementations are
-  `python/tutorials/tle/raw/nvshmem/02-allgather-gemm` (with a benchmark
-  harness against torch-native) and `03-gemm-allreduce`.
+  this cycle is NVIDIA (sm90+). Adaptation on NVIDIA is complete, and most
+  scenarios outperform torch-native; the gap to Triton-distributed is
+  being optimized. The fused implementations live in FlagTree under
+  `python/tutorials/tle/raw/nvshmem/`: `02-allgather-gemm` (with a
+  benchmark harness against torch-native) and `03-gemm-allreduce`.
   <!-- TODO: code locations for standalone AllGather / ReduceScatter and
        GEMM+ReduceScatter (not in the FlagTree tree as of 2026-08-25), and
        the Triton-distributed comparison method — add a variant to
@@ -127,13 +125,11 @@ substrate to a production inference scenario: GLM5.2 PD disaggregation on
 T-Head and MetaX, with 1 prefill + 1 decode instance (8+8 cards) and
 inter-instance KV transfers over the network; the setup runs in containers.
 Baseline for the ≥3% gain is Mooncake TransferEngine in its default
-configuration on the same topology.
-
-Status 2026-08-24: runs end-to-end on T-Head at roughly baseline
-performance; the optimization work targeting the gain is in progress and is
-prioritized on T-Head. MetaX waits on the platform's base optimization —
-GLM does not yet run normally there — so its PD acceptance comes later in
-the cycle.
+configuration on the same topology. It currently runs end-to-end on T-Head
+at roughly baseline performance, and the optimization work targeting the
+gain is prioritized there; on MetaX the platform's base optimization is not
+done and GLM does not yet run normally, so MetaX follows later in the
+cycle.
 
 <!-- TODO (design): source of the optimization — transfer overlap, NIC
      selection, noncontiguous KV layout handling, or other. -->
@@ -144,20 +140,20 @@ Standalone AllGather / ReduceScatter and fused AllGather+GEMM /
 GEMM+ReduceScatter operators, targeting intra-node and inter-node
 performance on par with Triton-distributed. The operators use the FlagCX
 Device API + IR bindings and NVSHMEM for intra-node and inter-node
-transfers; vendor scope this cycle is NVIDIA (sm90+).
+transfers; vendor scope this cycle is NVIDIA (sm90+). Adaptation on NVIDIA
+is complete; most scenarios outperform torch-native, and the gap to
+Triton-distributed is being optimized.
 
-Status 2026-08-24: adapted on NVIDIA, with most scenarios outperforming
-torch-native and the gap to Triton-distributed being optimized. What is in
-the FlagTree tree today (https://github.com/flagos-ai/FlagTree, under
-`python/tutorials/tle/raw/nvshmem/`): `02-allgather-gemm` and
-`03-gemm-allreduce`. The AG+GEMM directory carries a benchmark harness:
-it sweeps seven layer shapes (LLaMA-7B / 3.1-8B / 3.1-70B / 3.1-405B,
-Mistral-7B, Qwen2-72B, GPT-3-175B) at M=8192 (configurable via `--M`),
-fp16 or bf16, gates correctness first (`assert_allclose` at
-`atol=1e-3, rtol=1e-3` per rank), then times six variants — fused total,
-AG-only, GEMM-only, on both the FlagTree and torch sides — and
-`--dump_csv` writes `csv/perf_ag_gemm_<world_size>_ranks.csv` with speedup
-per shape. Run:
+The fused implementations live in FlagTree
+(https://github.com/flagos-ai/FlagTree) under
+`python/tutorials/tle/raw/nvshmem/`: `02-allgather-gemm` and
+`03-gemm-allreduce`. The AG+GEMM benchmark harness sweeps seven layer
+shapes (LLaMA-7B / 3.1-8B / 3.1-70B / 3.1-405B, Mistral-7B, Qwen2-72B,
+GPT-3-175B) at M=8192 (configurable via `--M`), fp16 or bf16, gates
+correctness first (`assert_allclose` at `atol=1e-3, rtol=1e-3` per rank),
+then times six variants — fused total, AG-only, GEMM-only, on both the
+FlagTree and torch sides — and `--dump_csv` writes
+`csv/perf_ag_gemm_<world_size>_ranks.csv` with speedup per shape. Run:
 `torchrun --nproc_per_node=<N> benchmark.py --dump_csv` (at least 2 GPUs,
 `WORLD_SIZE % LOCAL_WORLD_SIZE == 0`).
 
@@ -264,8 +260,8 @@ lands.
 
 Acceptance runs on vendor hardware; results (environment, logs, metrics) are
 attached to the tracking issue by the testing party. Topology: 1P+1D, 8+8
-cards, KV transfers over the network, containerized. T-Head is testable now;
-MetaX follows once its base platform optimization lands and GLM runs there.
+cards, KV transfers over the network, containerized. MetaX runs start once
+GLM runs normally there.
 
 | Test | Command | Expected result |
 |---|---|---|
@@ -278,12 +274,12 @@ Four operators in scope: AllGather, ReduceScatter, AllGather+GEMM,
 GEMM+ReduceScatter; acceptance target is intra-node and inter-node
 performance on par with Triton-distributed. NVIDIA sm90+ this cycle.
 
-The command below is the harness that exists in the FlagTree tree today
-(`02-allgather-gemm/benchmark.py`): it sweeps seven layer shapes (LLaMA-7B /
-3.1-8B / 3.1-70B / 3.1-405B, Mistral-7B, Qwen2-72B, GPT-3-175B) at M=8192
-(configurable via `--M`), fp16 or bf16, gates correctness first
-(`assert_allclose` at `atol=1e-3, rtol=1e-3` per rank), then times six
-variants: fused total, AG-only, GEMM-only, on both FlagTree and torch sides.
+The AllGather+GEMM harness (`02-allgather-gemm/benchmark.py`) sweeps seven
+layer shapes (LLaMA-7B / 3.1-8B / 3.1-70B / 3.1-405B, Mistral-7B, Qwen2-72B,
+GPT-3-175B) at M=8192 (configurable via `--M`), fp16 or bf16, gates
+correctness first (`assert_allclose` at `atol=1e-3, rtol=1e-3` per rank),
+then times six variants: fused total, AG-only, GEMM-only, on both FlagTree
+and torch sides.
 
 | Test | Command | Expected result |
 |---|---|---|
@@ -310,12 +306,10 @@ variants: fused total, AG-only, GEMM-only, on both FlagTree and torch sides.
 
 - 2026-07-30: FEP created as `Provisional` for the FlagOS 2.2 cycle; Features
   2 and 3 under design, Feature 1a merged on main.
-- 2026-08-24: Progress sync with development — T-Head adaptation complete and
-  testable; distributed operators adapted on NVIDIA; PD disaggregation runs
-  on T-Head with optimization in progress (baseline Mooncake); Kunlunxin
-  Device API PR expected ~09-10; MetaX PD moved to stretch (base platform
-  optimization pending); Ascend deferred behind the sglang-plugin Huawei P0.
-- 2026-08-25: FEP updated to the synced scope; Owner set.
-- 2026-08-25: Goals restored to the development-side feature list (PD on
-  T-Head and MetaX; four distributed operators with the Triton-distributed
-  parity target), with the 08-24 status and the open items kept as TODOs.
+- 2026-08-24: Progress sync with development — T-Head adaptation complete
+  and testable; distributed operators adapted on NVIDIA; PD disaggregation
+  runs on T-Head with optimization in progress (baseline Mooncake);
+  Kunlunxin Device API PR expected ~09-10; MetaX PD gated on its base
+  platform optimization; Ascend deferred behind the sglang-plugin Huawei
+  P0.
+- 2026-08-25: Owner set; scope and Test Plan updated after the sync.

--- a/fep/sig-network/0085-flagcx-flagos-2.2-new-features.md
+++ b/fep/sig-network/0085-flagcx-flagos-2.2-new-features.md
@@ -25,9 +25,8 @@ release cycle, on top of v0.13.0:
    end-to-end gain over the Mooncake TransferEngine baseline, building on the
    P2P Engine introduced in v0.13.0
    ([FEP-0021](0021-flagcx-v0.13.0-new-features.md)).
-3. **Distributed operators** — AllGather / ReduceScatter and the fused
-   AllGather+GEMM / GEMM+ReduceScatter operators on NVIDIA, benchmarked
-   against torch-native and Triton-distributed.
+3. **Distributed operators** — fused AllGather+GEMM and GEMM+AllReduce
+   operators (FlagTree) on NVIDIA, benchmarked against torch-native.
 
 Repository: https://github.com/flagos-ai/FlagCX
 
@@ -65,14 +64,17 @@ matrix grows to include T-Head and more Device API-capable backends.
   moves out unless that lands first.
   <!-- TODO: metric definition for the ≥3% (throughput/TTFT/goodput) and
        workload profile. -->
-- **G4 (Distributed operators):** Provide AllGather, ReduceScatter,
-  AllGather+GEMM and GEMM+ReduceScatter operators on NVIDIA (they build on
-  the Device API and IR bindings, so vendor scope follows Device API
-  availability). Adaptation is complete on NVIDIA; performance beats
-  torch-native in most scenarios, while parity with Triton-distributed is
-  still being optimized.
-  <!-- TODO: repo/PR pointers for the operator implementation, benchmark
-       tolerance vs. Triton-distributed, message-size range and topology. -->
+- **G4 (Distributed operators):** Fused AllGather+GEMM and GEMM+AllReduce
+  operators in FlagTree (`python/tutorials/tle/raw/nvshmem/02-allgather-gemm`
+  and `03-gemm-allreduce`) on NVIDIA. Both operators are adapted and tested;
+  benchmark harness (`benchmark.py`) times against torch-native as the
+  baseline and reports speedup. The operators build on FlagCX Device API + IR
+  bindings and NVSHMEM; vendor scope is NVIDIA (sm90+).
+  <!-- TODO: Triton-distributed baseline — whether to add a third variant to
+       benchmark.py or run their upstream benchmark separately, and which
+       version/commit. GEMM+ReduceScatter does not exist in FlagTree as of
+       2026-08-25; confirm whether it ships in this cycle or the FEP scope
+       should reflect the two operators that exist (AG+GEMM, GEMM+AR). -->
 
 ### Non-Goals
 
@@ -80,7 +82,8 @@ matrix grows to include T-Head and more Device API-capable backends.
   named in G2 (tracked per-vendor in future cycles).
 - PD disaggregation on platforms other than T-Head (and MetaX as a stretch)
   in this cycle.
-- Fused operators beyond the four listed in G4 (e.g. AlltoAll+GEMM for MoE).
+- Fused operators beyond AllGather+GEMM and GEMM+AllReduce (e.g. standalone
+  AllGather/ReduceScatter, GEMM+ReduceScatter, AlltoAll+GEMM for MoE).
 - Ascend enablement: blocked on a PCI-probe interface issue on the Ascend
   side; not pursued standalone in this cycle, tracked together with the
   sglang-plugin Huawei P0 work, which hits the same problem.
@@ -130,17 +133,28 @@ and GLM does not yet run normally, so MetaX follows later.
 
 ### Feature 3: Distributed Operators
 
-Provide standalone AllGather / ReduceScatter and communication-computation
-fused AllGather+GEMM / GEMM+ReduceScatter operators. They sit on the Device
-API and IR bindings, so this cycle's vendor scope is NVIDIA. Adaptation is
-complete on NVIDIA: most scenarios outperform torch-native; parity with
-Triton-distributed is the optimization target and is not yet reached
-everywhere.
+Fused AllGather+GEMM and GEMM+AllReduce operators in FlagTree
+(`python/tutorials/tle/raw/nvshmem/02-allgather-gemm` and `03-gemm-allreduce`),
+sm90+ only. Both operators are adapted and tested on NVIDIA with a benchmark
+harness that times against torch-native (separate AG, separate GEMM, and the
+fused path) and reports speedup per layer shape. The operators use FlagCX
+Device API + IR bindings and NVSHMEM for intra-node and inter-node transfers.
 
-<!-- TODO (design):
-     1. Where the operator code lands (repo/PRs) and the API surface exposed.
-     2. Benchmark protocol vs. torch-native and Triton-distributed —
-        versions, message sizes, GEMM shapes, topology. -->
+Repository: https://github.com/flagos-ai/FlagTree
+
+The benchmark sweeps seven layer shapes (LLaMA-7B / 3.1-8B / 3.1-70B / 3.1-405B,
+Mistral-7B, Qwen2-72B, GPT-3-175B) at M=8192 (configurable via `--M`), fp16 or
+bf16. Correctness is gated first (`assert_allclose` at `atol=1e-3, rtol=1e-3`
+per rank before timing), then six timing variants run: fused total, AG-only,
+GEMM-only, on both FlagTree and torch sides. `--dump_csv` writes
+`csv/perf_ag_gemm_<world_size>_ranks.csv` with speedup per shape.
+
+Run: `torchrun --nproc_per_node=<N> benchmark.py --dump_csv` (requires at least
+2 GPUs, `WORLD_SIZE % LOCAL_WORLD_SIZE == 0`).
+
+<!-- TODO: Triton-distributed baseline — whether to add a third variant to
+     benchmark.py or run their upstream benchmark separately, and which
+     version/commit. -->
 
 ## Design Details
 
@@ -246,14 +260,23 @@ cards, KV transfers over the network, containerized.
 
 ### G4: Distributed operators
 
-Baselines: torch-native collectives+GEMM, and Triton-distributed
-[TODO: version/commit], same hardware, same message sizes. NVIDIA only this
-cycle.
+FlagTree `python/tutorials/tle/raw/nvshmem/02-allgather-gemm` and
+`03-gemm-allreduce`, NVIDIA sm90+ only. Benchmark harness
+(`02-allgather-gemm/benchmark.py`) sweeps seven layer shapes (LLaMA-7B /
+3.1-8B / 3.1-70B / 3.1-405B, Mistral-7B, Qwen2-72B, GPT-3-175B) at M=8192
+(configurable via `--M`), fp16 or bf16. Correctness gated first
+(`assert_allclose` at `atol=1e-3, rtol=1e-3` per rank), then times six
+variants: fused total, AG-only, GEMM-only, on both FlagTree and torch sides.
 
 | Test | Command | Expected result |
 |---|---|---|
-| AllGather / ReduceScatter | <!-- TODO: benchmark command --> | Outperforms torch-native in the covered scenarios; gap to Triton-distributed recorded per message size |
-| AllGather+GEMM / GEMM+ReduceScatter | <!-- TODO: benchmark command, GEMM shapes --> | Outperforms torch-native in the covered scenarios; gap to Triton-distributed recorded per shape |
+| AllGather+GEMM | `cd python/tutorials/tle/raw/nvshmem/02-allgather-gemm && torchrun --nproc_per_node=<N> benchmark.py --dump_csv` (requires ≥2 GPUs, sm90+, `WORLD_SIZE % LOCAL_WORLD_SIZE == 0`) | Correctness passes per rank; FlagTree fused path outperforms torch-native total latency in the covered shapes; csv written to `csv/perf_ag_gemm_<world_size>_ranks.csv` with speedup column |
+
+GEMM+AllReduce operator exists at `03-gemm-allreduce`; test command TBD.
+
+<!-- TODO: Triton-distributed baseline — whether to add a third timing variant
+     to benchmark.py or run their upstream benchmark separately, which
+     version/commit, and what the acceptance gap is. -->
 
 ## Related PRs
 

--- a/fep/sig-network/0085-flagcx-flagos-2.2-new-features.md
+++ b/fep/sig-network/0085-flagcx-flagos-2.2-new-features.md
@@ -1,4 +1,4 @@
-# FEP-NNNN: FlagCX New Features for FlagOS 2.2
+# FEP-0085: FlagCX New Features for FlagOS 2.2
 
 **Status:** `Provisional`
 

--- a/fep/sig-network/NNNN-flagcx-flagos-2.2-new-features.md
+++ b/fep/sig-network/NNNN-flagcx-flagos-2.2-new-features.md
@@ -1,0 +1,226 @@
+# FEP-NNNN: FlagCX New Features for FlagOS 2.2
+
+**Status:** `Provisional`
+
+**Created:** 2026-07-30
+
+**Owner:** [TODO: @github-username]
+
+**SIG:** sig-network
+
+**Target Version:** FlagOS 2.2
+
+---
+
+## Summary
+
+**(Required)** This FEP covers the FlagCX features planned for the FlagOS 2.2
+release cycle, on top of v0.13.0:
+
+1. **Vendor adaptation** — T-Head (PPU) backend support, bringing FlagCX to 13
+   supported chip backends; extend the FlagCX Device API adaptor interface to
+   2+ additional domestic chips.
+2. **PD-disaggregation support and optimization for inference** — run
+   prefill-decode disaggregation for GLM5.2 on T-Head and MetaX platforms with
+   3+% end-to-end gain, building on the P2P Engine introduced in v0.13.0
+   ([FEP-0021](0021-flagcx-v0.13.0-new-features.md)).
+3. **Distributed operators** — AllGather / ReduceScatter and the fused
+   AllGather+GEMM / GEMM+ReduceScatter operators, with intra-node and
+   inter-node performance on par with Triton-distributed.
+
+Repository: https://github.com/flagos-ai/FlagCX
+
+## Motivation
+
+FlagOS 2.2 extends FlagCX along the two axes established in previous cycles:
+breadth of domestic chip coverage, and depth of LLM-workload support. The P2P
+Engine and Device API foundations shipped in v0.13.0 now need to be carried
+into production inference scenarios (PD disaggregation) and into
+compute-communication fusion (distributed operators), while the vendor adaptor
+matrix grows to include T-Head and more Device API-capable backends.
+
+### Goals
+
+**(Required)**
+
+- **G1 (T-Head adaptation):** Support the T-Head PPU backend (device adaptor
+  `ppu_cuda_adaptor` + CCL adaptor `ppu_nccl_adaptor`, build flag `USE_PPU=1`),
+  bringing the in-tree chip backend count to 13.
+- **G2 (Device API adaptor expansion):** Extend the Device API vendor traits
+  interface (`flagcx/adaptor/include/device_api/*_comm_traits.h` /
+  `*_platform_traits.h`, currently implemented for NVIDIA, Hygon DU and
+  Sunrise) to at least 2 additional domestic chips.
+  <!-- TODO: name the target vendors and the Device API primitive subset that
+       must pass tests to count as supported. -->
+- **G3 (PD disaggregation):** GLM5.2 prefill-decode disaggregation runs
+  end-to-end on T-Head and MetaX platforms using the FlagCX P2P Engine as the
+  KV transfer substrate, with ≥3% end-to-end gain.
+  <!-- TODO: define the ≥3% measurement — metric (throughput/TTFT/goodput),
+       baseline, serving framework and workload profile. -->
+- **G4 (Distributed operators):** Provide AllGather, ReduceScatter,
+  AllGather+GEMM and GEMM+ReduceScatter operators whose intra-node and
+  inter-node performance is on par with Triton-distributed.
+  <!-- TODO: define "on par" — Triton-distributed baseline version, tolerance,
+       message-size range, GPU count and topology, per operator. -->
+
+### Non-Goals
+
+- Device API CustomAllReduce / IR bindings support on vendors beyond the ones
+  named in G2 (tracked per-vendor in future cycles).
+- PD disaggregation on platforms other than T-Head and MetaX in this cycle.
+- Fused operators beyond the four listed in G4 (e.g. AlltoAll+GEMM for MoE).
+
+## Proposal
+
+### Feature 1: Vendor Adaptation
+
+**1a. T-Head (PPU) backend.** Already merged on main
+(flagos-ai/FlagCX#512): adds `flagcx/adaptor/device/ppu_cuda_adaptor.cc` and
+`flagcx/adaptor/ccl/ppu_nccl_adaptor.cc` behind `USE_PPU=1`, following the
+existing per-vendor adaptor pattern. With PPU, the in-tree CCL adaptor matrix
+covers 13 chip backends: NVIDIA (nccl), Ascend (hccl), Iluvatar (ixnccl),
+Cambricon (cncl), MetaX (mccl), Moore Threads (musa_mccl), Kunlunxin (xccl),
+AMD (rccl), Hygon (dunccl), TsingMicro (tccl), Enflame (eccl), Sunrise (pccl),
+T-Head (ppu_nccl).
+
+**1b. Device API adaptor interface for 2+ domestic chips.** The Device API
+(v0.11–v0.13) dispatches device-side communication primitives through
+per-vendor traits (`comm_traits.h` / `platform_traits.h`); today only NVIDIA,
+Hygon DU and Sunrise have vendor traits, with a default fallback. This work
+adds traits implementations (and, where needed, kernel compilation pipeline
+support) for additional domestic chips so they can use Device API-based
+features such as CustomAllReduce.
+
+<!-- TODO (design): per target vendor — native primitives vs. default
+     fallback; LLVM bitcode path availability; symmetric-window vs. IPC-only
+     registration. -->
+
+### Feature 2: PD Disaggregation Support and Optimization
+
+Builds on the v0.13.0 P2P Engine (one-sided RDMA, vectorized read/write,
+topology-aware NIC selection) and its NIXL integration
+(`plugin/nixl/flagcx_p2p_on_nixl_v1.1.0.patch`). This cycle takes that
+substrate to a production inference scenario: GLM5.2 PD disaggregation on
+T-Head and MetaX.
+
+<!-- TODO (design):
+     1. Integration path — vLLM KV-transfer connector, NIXL backend, or both;
+        serving framework versions on T-Head / MetaX.
+     2. Gaps on these two platforms (P2P Engine has been validated on
+        NVIDIA / Mthreads / MetaX / Hygon; what does T-Head need).
+     3. Source of the optimization — transfer overlap, NIC selection,
+        noncontiguous KV layout handling, or other. -->
+
+### Feature 3: Distributed Operators
+
+Provide standalone AllGather / ReduceScatter and communication-computation
+fused AllGather+GEMM / GEMM+ReduceScatter operators, benchmarked against
+Triton-distributed, targeting parity intra-node and inter-node.
+
+<!-- TODO (design):
+     1. Execution model — device-initiated kernels on the Device API IR
+        bindings, or host-side chunked scheduling overlapping collectives with
+        GEMM launches.
+     2. API surface — C/C++ host API, torch ops (plugin/torch), or
+        Triton-language builtins.
+     3. Vendor scope for this cycle.
+     4. Relationship to Triton-distributed — reuse of kernels/algorithms, or
+        independent implementation with it as benchmark baseline only. -->
+
+## Design Details
+
+<!-- TODO: architecture and data-flow details for Features 1b/2/3, to be
+     filled before Status moves to `Implementable`. -->
+
+## Packaging
+
+Built from source per backend; no wheel is published for the core library.
+
+### Obtain Source Code
+
+```bash
+git clone https://github.com/flagos-ai/FlagCX.git
+cd FlagCX
+git submodule update --init --recursive
+```
+
+### Build
+
+```bash
+# Core library — choose your backend flag
+make <backend>=1 -j$(nproc)
+
+# T-Head PPU backend (Feature 1a)
+make USE_PPU=1 -j$(nproc)
+
+# Device API kernel support (Features 1b / 3, where applicable)
+make USE_NVIDIA=1 COMPILE_KERNEL=1 -j$(nproc)
+```
+
+`<backend>` is one of: `USE_NVIDIA`, `USE_ASCEND`, `USE_ILUVATAR_COREX`,
+`USE_CAMBRICON`, `USE_METAX`, `USE_MUSA`, `USE_KUNLUNXIN`, `USE_AMD`,
+`USE_DU`, `USE_TSM`, `USE_ENFLAME`, `USE_SUNRISE`, `USE_PPU`.
+
+### Dependencies
+
+- MPI (multi-process tests): OpenMPI or mpich
+- libibverbs (IBRC P2P adaptor, required for PD disaggregation transfers)
+- Vendor toolkit per backend (CUDA toolkit for NVIDIA, etc.)
+<!-- TODO: T-Head and MetaX toolchain/driver versions for Feature 2;
+     serving-framework version pins. -->
+
+### Multi-Platform Support
+
+| Feature | Platform scope (this cycle) |
+|---|---|
+| T-Head backend | T-Head PPU |
+| Device API adaptor expansion | [TODO: 2+ named vendors] |
+| PD disaggregation (GLM5.2) | T-Head, MetaX |
+| Distributed operators | [TODO] |
+
+## Test Plan
+
+**(Required)** Each goal is verified independently, reusing the existing test
+infrastructure (`test/perf/host_api`, `test/perf/kv_transfer`,
+`test/perf/device_api`).
+
+### G1: T-Head backend
+
+| Test | Command | Expected result |
+|---|---|---|
+| Build | `make USE_PPU=1 -j$(nproc)` | Library builds without errors |
+| Collectives correctness/perf | `cd test/perf/host_api && make USE_PPU=1`, run perf binaries via mpirun on a T-Head node <!-- TODO: binary list, rank count, expected bandwidth --> | All collectives pass correctness check |
+
+### G2: Device API adaptor expansion
+
+<!-- TODO: per new vendor — build flag, required Device API test binaries
+     (test/device_api unit tests, perf_allreduce_intranode, ...), hardware. -->
+
+### G3: PD disaggregation (GLM5.2 on T-Head / MetaX)
+
+Acceptance runs on vendor hardware; results (environment, logs, metrics) are
+attached to the tracking issue by the testing party.
+
+| Test | Command | Expected result |
+|---|---|---|
+| KV transfer micro-benchmark | `test/perf/kv_transfer/kv_transfer_benchmark.py` on the target platform <!-- TODO: args, expected bandwidth --> | Transfer bandwidth within expected range |
+| E2E PD disaggregation | <!-- TODO: prefill/decode instance launch commands, workload driver, metric collection --> | GLM5.2 serves correctly in PD mode on T-Head and MetaX; ≥3% gain in [TODO: metric] vs. [TODO: baseline] |
+
+### G4: Distributed operators vs. Triton-distributed
+
+Baseline: Triton-distributed [TODO: version/commit], same hardware, same
+message sizes.
+
+| Test | Command | Expected result |
+|---|---|---|
+| AllGather / ReduceScatter | <!-- TODO: benchmark command --> | Within [TODO: tolerance] of baseline, intra- and inter-node |
+| AllGather+GEMM / GEMM+ReduceScatter | <!-- TODO: benchmark command, GEMM shapes --> | Within [TODO: tolerance] of baseline, intra- and inter-node |
+
+## Related PRs
+
+- [x] flagos-ai/FlagCX#512 — [PAL] Add PPU support (T-Head backend)
+
+## Implementation History
+
+- 2026-07-30: FEP created as `Provisional` for the FlagOS 2.2 cycle; Features
+  2 and 3 under design, Feature 1a merged on main.


### PR DESCRIPTION
FEP for the FlagCX features in the FlagOS 2.2 cycle, on top of v0.13.0:

- **Vendor adaptation** — T-Head (PPU) backend merged (flagos-ai/FlagCX#512), 13th in-tree chip backend, testable now. Device API adaptor interface extended to 2 more domestic chips: Kunlunxin first (vendor PR expected ~09-10), second vendor targeted within the window with schedule risk.
- **PD disaggregation (GLM5.2)** — T-Head and MetaX, 1P+1D 8+8 cards; ≥3% end-to-end gain vs. Mooncake TransferEngine (default). Runs on T-Head at ~parity with optimization in progress; MetaX gated on its base platform optimization (GLM not yet running there).
- **Distributed operators** — AllGather, ReduceScatter, AllGather+GEMM, GEMM+ReduceScatter, targeting intra-/inter-node parity with Triton-distributed; NVIDIA sm90+ this cycle, built on the FlagCX Device API + IR bindings (#539/#545). Adapted on NVIDIA, most scenarios beat torch-native. The fused implementations live in FlagTree (`02-allgather-gemm` with a benchmark harness vs. torch-native, `03-gemm-allreduce`); standalone AG/RS and GEMM+RS code locations plus the Triton-distributed comparison method are open TODOs.
- Ascend under Non-Goals: blocked on a PCI-probe interface issue, tracked with the sglang-plugin Huawei P0 work.

Test Plan carries the pre-testing inputs from development (official command doc, per-vendor API compatibility list — CI currently covers NVIDIA/MetaX/Hygon) and the 2.2 scope rule (existing features tested to 2.1 scope more thoroughly; new features only within the stated support scope).

Status stays `Provisional` until the open TODOs are filled: second Device API vendor, ≥3% metric definition, operator code locations, Triton-distributed baseline method. Owner: @MC952-arch. Feature Freeze 2026-08-31.