### PR TITLE
FEP(sig-framework): FlagOS-Compressor model quantization framework

### DIFF
--- a/fep/sig-framework/0091-flagos-compressor-first-release.md
+++ b/fep/sig-framework/0091-flagos-compressor-first-release.md
@@ -1,4 +1,4 @@
-# FEP: FlagOS-Compressor — Model Quantization Framework (First Release)
+# FEP-0091: FlagOS-Compressor — Model Quantization Framework (First Release)
 
 **Status:** `Provisional`
 

--- a/fep/sig-framework/0091-flagos-compressor-first-release.md
+++ b/fep/sig-framework/0091-flagos-compressor-first-release.md
@@ -151,5 +151,5 @@ modules, so new formats/methods extend without core changes.
 
 ## Implementation History
 
-- 2026-07-30: FEP created as `Provisional` for the FlagOS 2.2 cycle, from
-  the framework-group 2.2 release plan; repository bootstrapped 2026-07-14.
+- 2026-07-30: FEP created as `Provisional` for the FlagOS 2.2 cycle;
+  repository bootstrapped 2026-07-14.

--- a/fep/sig-framework/0091-flagos-compressor-first-release.md
+++ b/fep/sig-framework/0091-flagos-compressor-first-release.md
@@ -1,10 +1,10 @@
 # FEP-0091: FlagOS-Compressor — Model Quantization Framework (First Release)
 
-**Status:** `Provisional`
+**Status:** `Implementable`
 
 **Created:** 2026-07-30
 
-**Owner:** [TODO: @github-username]
+**Owner:** [@rdzhu225](https://github.com/rdzhu225)
 
 **SIG:** sig-framework
 
@@ -511,7 +511,10 @@ included), merged 2026-07-29.
 - 2026-07-14: repository bootstrapped.
 - 2026-07-30: FEP created as `Provisional` for the FlagOS 2.2 cycle.
 - 2026-08-04: `release/v0.1.0` cut at commit `eecf2fa`, after PR #5.
+- 2026-08-24: `v0.1.0-rc1` tagged at `eecf2fa`.
 - 2026-08-25: FEP scope aligned to the release branch — INT8, per-channel
   INT8, and dynamic-token W8A8 moved from Non-Goals into G2; calibrated
   methods recorded as out of scope; Test Plan rewritten with the acceptance
   commands and expected results.
+- 2026-08-25: Status raised to `Implementable` — implementation complete on
+  `release/v0.1.0`, acceptance testing ahead.

--- a/fep/sig-framework/0091-flagos-compressor-first-release.md
+++ b/fep/sig-framework/0091-flagos-compressor-first-release.md
@@ -14,7 +14,7 @@
 
 ## Summary
 
-**(Required)** This FEP proposes the first release (v0.1.0) of
+This FEP proposes the first release (v0.1.0) of
 FlagOS-Compressor, the FlagOS weight-format conversion and quantization
 tool, in the FlagOS 2.2 cycle. The tool reads a local HuggingFace sharded
 `safetensors` model directory and writes a new model directory. It covers
@@ -30,7 +30,6 @@ four areas:
 4. `inspect`, `--dry-run`, and `validate` for planning a run and checking
    the output directory before it reaches an inference stack.
 
-The tool was bootstrapped as FlagCompressor and renamed FlagOS-Compressor.
 As a new module and repository, this FEP also serves as the module's
 admission proposal, which the FEP rules require for a new repository.
 
@@ -38,9 +37,9 @@ Repository: https://github.com/flagos-ai/FlagOS-Compressor
 
 Release branch for 2.2 acceptance:
 https://github.com/flagos-ai/FlagOS-Compressor/tree/release/v0.1.0
-(cut at commit `eecf2fa`, 2026-08-04). Everything this FEP claims for 2.2
-is scoped to that branch. `main` has since taken calibrated quantization
-work (PR #6) that is outside this release; see Non-Goals.
+(cut at commit `eecf2fa`, 2026-08-04). This FEP is scoped to that branch.
+`main` has since taken calibrated quantization work (PR #6) that is outside
+this release; see Non-Goals.
 
 ## Motivation
 
@@ -54,13 +53,10 @@ stacks already read.
 Module-level control matters because routed experts, shared experts,
 attention projections, and dense MLP weights differ both in sensitivity and
 in kernel availability. A run often needs to quantize routed experts while
-leaving attention in BF16, or the reverse. One-shot conversion scripts do
-not offer that selection, cannot express a mixed-precision product, and
-leave no reproducible record of what was quantized.
+leaving attention in BF16, or the reverse. One-shot conversion scripts do not
+offer that selection and leave no record of what was quantized.
 
 ### Goals
-
-**(Required)**
 
 - **G1 (BF16 dequantization):** MXFP4 (E2M1 + E8M0, 32-value groups) and
   block FP8 (E8M0 scale per padded 128x128 tile) inputs dequantize to BF16;
@@ -134,16 +130,14 @@ A command-line tool, `flagos-compressor`, with four subcommands:
   weights to BF16.
 - `validate --input <dir> [--json]` — check a produced directory.
 
-Input and output must be different directories. A run is expected to go
-`inspect` → `quantize --dry-run` → `quantize` → `validate`, because
-`--dry-run` prints the resolved W/A bit widths, strategy, group size, the
-per-format tensor counts, and the count of scaled byte tensors whose layout
-was not recognized. That count must be zero before a real run; the tool
-refuses to guess an unrecognized layout rather than emitting silently wrong
-weights.
+Input and output must be different directories. A run goes `inspect`,
+`quantize --dry-run`, `quantize`, `validate`. The dry run prints the resolved
+W/A bit widths, strategy, group size, the per-format tensor counts, and the
+count of scaled byte tensors whose layout was not recognized. That count must
+be zero before a real run; an unrecognized layout is refused, not guessed.
 
-Selection safety rules the planner enforces, all of which surface at
-`--dry-run` time:
+Selection rules the planner enforces, all of which surface at `--dry-run`
+time:
 
 - A regex may not split a fused inference unit, and may not select part of
   a routed-expert bank. Either the whole bank is quantized or none of it is.
@@ -179,11 +173,11 @@ editing the planner.
 
 Fused 3D routed-expert banks get their axis order from a `MoeLayout`
 adapter chosen by `config.json` (`model_type`, nested `text_config`
-`model_type`, then `architectures`), not from the tensor name. This is
-deliberate: Qwen3.5-MoE stores `[num_experts, out, in]` while Qwen3-VL-MoE
+`model_type`, then `architectures`), not from the tensor name. Qwen3.5-MoE
+stores `[num_experts, out, in]` while Qwen3-VL-MoE
 stores `[num_experts, in, out]`, and both use the same
-`experts.gate_up_proj` / `experts.down_proj` names. Selecting by name would
-quantize along the wrong axis for one of them, so v0.1.0 registers only the
+`experts.gate_up_proj` / `experts.down_proj` names, so selecting by name would
+quantize along the wrong axis for one of them. v0.1.0 registers only the
 verified Qwen3.5-MoE layout and raises
 `Fused routed-expert quantization is not supported for this model` for
 anything else. On quantization the bank is expanded into standard
@@ -193,7 +187,7 @@ Peak memory during the MSE search is bounded by a group chunk size
 (`--chunk-size`, default 4096 for INT4 and 1024 for INT8) rather than by
 holding a whole layer's candidate set.
 
-Each run writes machine-readable provenance next to the weights:
+Each run writes provenance next to the weights:
 `quantization_manifest.json` (schema `flagos-compressor.provenance.v1`:
 per-tensor format, bit width, strategy, scale name, storage and logical
 shape) and `quantization_report.json` (counts, elapsed time, requested
@@ -246,7 +240,7 @@ driver.
 
 ## Test Plan
 
-**(Required)** The repository carries a `tests/` suite covering the tensor
+The repository carries a `tests/` suite covering the tensor
 classifier, policy and planner, INT4 and INT8 quantization, fused MoE INT4,
 FP4 decoding, recipes, compressed-tensors config, and an end-to-end path:
 
@@ -298,10 +292,9 @@ flagos-compressor validate --input "$OUT/source-bf16"
 Expected result: `inspect` reports the source weights as `fp4_e2m1_e8m0` or
 `fp8_block_e8m0` with `unmatched quantized: 0`; `convert` writes a BF16
 directory plus `conversion_report.json`; `validate` prints `Valid`. On a
-BF16 or FP16 input, `convert` instead fails with
-`No supported FP8/FP4 tensors were found`, which is the correct behavior and
-is recorded as such. Numerical check against a reference dequantization is
-pending the tolerance TODO above.
+BF16 or FP16 input, `convert` is expected to fail with
+`No supported FP8/FP4 tensors were found`. Numerical check against a
+reference dequantization is pending the tolerance TODO above.
 
 ### G2 — INT4 / INT8 export
 
@@ -309,12 +302,12 @@ Feature: W4A16, W8A16 group, W8A16 channel, W8A8. Run on
 `$MODEL_QWEN_DENSE`, varying only the quantization flags:
 
 ```bash
-# W8A16 group-128 — the conservative baseline, generated first
+# W8A16 group-128
 flagos-compressor quantize --input "$MODEL_QWEN_DENSE" \
   --output "$OUT/dense-w8a16-g128" \
   --select linear --bits 8 --strategy group --group-size 128 --backend cuda
 
-# W4A16 group-32 — maximum weight compression
+# W4A16 group-32
 flagos-compressor quantize --input "$MODEL_QWEN_DENSE" \
   --output "$OUT/dense-w4a16-g32" \
   --select linear --bits 4 --strategy group --group-size 32 --backend cuda
@@ -431,14 +424,12 @@ product, the manifest carries expanded
 `experts.<id>.<projection>.weight` and `weight_scale` entries rather than
 fused bank names. A model with a fused 3D expert bank and no registered
 layout must fail before writing weights, with
-`Fused routed-expert quantization is not supported for this model`; that
-guard is not to be bypassed for acceptance.
+`Fused routed-expert quantization is not supported for this model`.
 
 One case applies to any model whose `self_attn` contains an auxiliary
 `indexer` submodule. Its inner weights carry attention-like leaf names, so
-`--select attention` picks them up even though they are not a general
-quantization target. Check whether a candidate model has them, and exclude
-them if so:
+`--select attention` picks them up. Check whether a candidate model has them,
+and exclude them if so:
 
 ```bash
 grep -o 'self_attn\.indexer' "$INPUT/model.safetensors.index.json" | head -1
@@ -480,12 +471,11 @@ versions, whether the log reports the intended scheme, and whether any
 kernel fallback occurred. A BF16 or source-float reference is served on the
 same stack for an accuracy A/B, and peak memory, TTFT, TPOT, and throughput
 are recorded alongside it. Load and accuracy acceptance is planned on
-NVIDIA GPU, PPU, and Hygon DCU; each target is verified independently, since
-a valid product does not imply a kernel exists on a given chip.
+NVIDIA GPU, PPU, and Hygon DCU, each verified independently, since a valid
+product does not imply a kernel exists on a given chip.
 
-A `Valid` product that fails to load is a serving-side result, not a
-product-side one, and is recorded against the stack and chip rather than
-against this FEP's G1–G5.
+A `Valid` product that fails to load is recorded against the stack and chip
+rather than against G1–G5.
 
 <!-- TODO: name the serving stack and version used for the load tests, and
      the accuracy datasets for the A/B, once vllm-plugin-FL's

--- a/fep/sig-framework/0091-flagos-compressor-first-release.md
+++ b/fep/sig-framework/0091-flagos-compressor-first-release.md
@@ -87,9 +87,9 @@ first-class FlagOS component.
   weight-only in this release; only the MSE method is accepted by the
   recipe schema).
 - Activation quantization (W4A16 means activations stay 16-bit).
-- INT8 weight quantization — in progress (#3) but not part of the first
+- INT8 weight quantization — merged on main (#3) but not part of the first
   release's acceptance.
-  <!-- TODO: confirm whether INT8 lands in 2.2 or the next cycle. -->
+  <!-- TODO: confirm whether INT8 is accepted in 2.2 or the next cycle. -->
 
 ## Proposal
 
@@ -147,7 +147,7 @@ modules, so new formats/methods extend without core changes.
 
 - [x] flagos-ai/FlagOS-Compressor#1 — feat: bootstrap FlagCompressor — safetensors weight-format conversion with BF16 dequant and policy-driven INT4 quantization
 - [x] flagos-ai/FlagOS-Compressor#2 — feat: support fused MoE INT4 packing and compressed-tensors output
-- [ ] flagos-ai/FlagOS-Compressor#3 — feat(quantization): add INT8 weight quantization
+- [x] flagos-ai/FlagOS-Compressor#3 — feat(quantization): add INT8 weight quantization
 
 ## Implementation History
 

--- a/fep/sig-framework/0091-flagos-compressor-first-release.md
+++ b/fep/sig-framework/0091-flagos-compressor-first-release.md
@@ -14,142 +14,514 @@
 
 ## Summary
 
-**(Required)** This FEP proposes the first release of **FlagOS-Compressor**
-(initially bootstrapped as FlagCompressor, renamed FlagOS-Compressor), the
-FlagOS model quantization and weight-format conversion framework, in the
-FlagOS 2.2 cycle. It converts and quantizes HuggingFace `safetensors`
-checkpoints:
+**(Required)** This FEP proposes the first release (v0.1.0) of
+FlagOS-Compressor, the FlagOS weight-format conversion and quantization
+tool, in the FlagOS 2.2 cycle. The tool reads a local HuggingFace sharded
+`safetensors` model directory and writes a new model directory. It covers
+four areas:
 
-1. **BF16 dequantization** — end-to-end FP4 (E2M1 + E8M0) / FP8 (block +
-   E8M0) → BF16 dequantization, with BF16 pass-through.
-2. **INT4 weight quantization** — groupwise MSE INT4 with BF16 scales,
-   written directly as an inference-ready compressed-tensors
-   `pack-quantized` W4A16 checkpoint.
-3. **Selector + Recipe** — built-in selection groups (`moe`, `moe.routed`,
-   `moe.shared`, `attention`, `mlp`) combinable via `--select`; unselected
-   low-precision weights are converted to BF16 or kept, enabling
-   mixed-precision outputs.
-4. **Dry-run + inspect** — `--dry-run` previews the execution plan;
-   `inspect --json` emits a machine-readable model profile.
+1. BF16 dequantization of MXFP4 (E2M1 + E8M0) and block FP8 (128x128 tile +
+   E8M0) source weights, with floating-point weights passed through.
+2. Weight-only INT4 and INT8 quantization by groupwise or per-channel MSE
+   search, exported as compressed-tensors W4A16 / W8A16, plus dynamic
+   per-token W8A8.
+3. Module selection and YAML recipes, so a run quantizes a chosen set of
+   linear layers and converts the rest to BF16.
+4. `inspect`, `--dry-run`, and `validate` for planning a run and checking
+   the output directory before it reaches an inference stack.
 
+The tool was bootstrapped as FlagCompressor and renamed FlagOS-Compressor.
 As a new module and repository, this FEP also serves as the module's
-admission proposal per the FEP rules ("New module / new repository:
-Required").
+admission proposal, which the FEP rules require for a new repository.
 
 Repository: https://github.com/flagos-ai/FlagOS-Compressor
 
+Release branch for 2.2 acceptance:
+https://github.com/flagos-ai/FlagOS-Compressor/tree/release/v0.1.0
+(cut at commit `eecf2fa`, 2026-08-04). Everything this FEP claims for 2.2
+is scoped to that branch. `main` has since taken calibrated quantization
+work (PR #6) that is outside this release; see Non-Goals.
+
 ## Motivation
 
-Mainstream open checkpoints increasingly ship in low-precision storage
-formats (MXFP4, block FP8), while the chips FlagOS targets differ in which
-formats they can execute. Deploying one model across the FlagOS chip fleet
-therefore needs a format bridge: dequantize vendor-incompatible formats to
-BF16, or re-quantize selected weights to widely-executable INT4 (W4A16) —
-with module-level control, because MoE experts, attention, and MLP weights
-have different sensitivity and different hardware support. Existing
-one-shot conversion scripts do not offer selection, mixed-precision
-products, or reproducible recipes; FlagOS-Compressor provides these as a
-first-class FlagOS component.
+Open checkpoints increasingly ship in low-precision storage formats such as
+MXFP4 and block FP8, and the chips FlagOS targets differ in which of those
+formats they can execute. Serving one model across the FlagOS chip fleet
+needs a format bridge: dequantize a format the target cannot execute to
+BF16, or re-quantize selected weights to INT4/INT8 in a format inference
+stacks already read.
+
+Module-level control matters because routed experts, shared experts,
+attention projections, and dense MLP weights differ both in sensitivity and
+in kernel availability. A run often needs to quantize routed experts while
+leaving attention in BF16, or the reverse. One-shot conversion scripts do
+not offer that selection, cannot express a mixed-precision product, and
+leave no reproducible record of what was quantized.
 
 ### Goals
 
 **(Required)**
 
-- **G1 (BF16 dequantization):** FP4 (E2M1 + E8M0) and FP8 (block + E8M0)
-  inputs dequantize end-to-end to BF16; BF16 inputs pass through. Format
-  handlers in-tree: `fp4_e2m1`, `fp8_e8m0`, `bf16`, `floating`.
-- **G2 (INT4 quantization):** Groupwise MSE INT4 (`quantizers/mse_int4.py`,
-  default group size 32) with BF16 scales, emitting compressed-tensors
-  `pack-quantized` W4A16 output (`formats/int4_pack.py`,
-  `compressed_tensors.py`, `compressed_tensors_moe.py` — fused-MoE INT4
-  packing landed in #2) and updating `config.json`; no post-quantization
-  conversion step.
-- **G3 (Selector + Recipe):** Built-in groups `moe` / `moe.routed` /
-  `moe.shared` / `attention` / `mlp` (plus `linear`), name-pattern
-  select/exclude, unselected-weight strategy (convert-to-BF16 or keep), and
-  a versioned YAML recipe format capturing method / group size / selection
-  for reproducible runs.
-- **G4 (Model coverage):** Sharded HuggingFace safetensors input (models
-  with a `model.safetensors.index.json`); conversion and quantization paths
-  verified on mainstream MoE models (DeepSeek-V3-class, Qwen MoE class) and
-  mainstream dense models (Qwen dense class). Supported input storage
-  formats: MXFP4 (E2M1 + E8M0), block FP8 + E8M0, BF16.
-- **G5 (Hardware backends):** CPU (torch CPU backend) and CUDA (torch CUDA
-  backend, with the quantization search path GPU-accelerated), switchable
-  via `--backend cpu|cuda` (`backends/cpu.py`, `cuda.py`).
+- **G1 (BF16 dequantization):** MXFP4 (E2M1 + E8M0, 32-value groups) and
+  block FP8 (E8M0 scale per padded 128x128 tile) inputs dequantize to BF16;
+  floating-point inputs pass through. Source format is inferred from weight
+  dtype and paired scale shape, and an unrecognized byte-width weight with a
+  scale is refused rather than guessed. Format handlers in-tree:
+  `fp4_e2m1`, `fp8_e8m0`, `bf16`, `floating`.
+- **G2 (INT4/INT8 weight quantization):** Symmetric MSE search
+  (`quantizers/mse_int4.py`, `mse_int8.py`) over a configurable candidate
+  count, exported as compressed-tensors:
+  - W4A16 groupwise, default group size 32, `pack-quantized` int32 storage
+    with BF16 scales.
+  - W8A16 groupwise (default group size 128) and per-output-channel,
+    `pack-quantized` int32 storage with BF16 scales.
+  - W8A8: per-output-channel INT8 weights with FP32 scales and dynamic
+    symmetric per-token INT8 activations, `int-quantized` storage.
+  The quantize command writes the inference-ready checkpoint and its
+  `config.json` `quantization_config` directly; there is no separate
+  post-quantization conversion step.
+- **G3 (Selection + Recipe):** Built-in groups `linear`, `attention`,
+  `mlp`, `moe`, `moe.routed`, `moe.shared`, combinable across repeated
+  `--select`; regex `--select-name` / `--exclude-name` and group
+  `--exclude`; unselected source-quantized weights converted to BF16 so one
+  run can produce a mixed-precision directory. A versioned YAML recipe
+  (`version: 1`) expresses the same run declaratively, merging its
+  selectors with CLI selectors and yielding scalar fields to explicit CLI
+  values.
+- **G4 (Model coverage):** Sharded HuggingFace safetensors input, meaning a
+  directory carrying `model.safetensors.index.json`. Structural coverage:
+  dense models, 2D routed and shared experts, MLA attention naming
+  (`q_a_proj`, `q_b_proj`, `kv_a_proj_with_mqa`, `kv_b_proj`, `wq_a`,
+  `wq_b`, `wkv_a`, `wkv_b`), and fused 3D routed-expert banks for the one
+  layout with a registered adapter, Qwen3.5-MoE (`[num_experts, out, in]`,
+  `gate_up_proj` split along the output axis). A model whose fused-expert
+  axis order has no registered adapter is refused. Acceptance targets in
+  the Test Plan: a Qwen3.5 dense model, a Qwen3.5-MoE model, and a
+  DeepSeek-class MoE model.
+- **G5 (Execution backends):** `--backend cpu` and `--backend cuda` for the
+  conversion and MSE search work, selected per run, with per-op CPU
+  fallback recorded in the run report.
 
 ### Non-Goals
 
-- Quantized *inference* — executing the W4A16 product is the serving
-  stack's job (e.g. vllm-plugin-FL, which is adding compressed-tensors
-  W4A16 support separately in flagos-ai/vllm-plugin-FL#313).
-- Quantization-aware training or calibration-dataset-based methods (PTQ
-  weight-only in this release; only the MSE method is accepted by the
-  recipe schema).
-- Activation quantization (W4A16 means activations stay 16-bit).
-- INT8 weight quantization — merged on main (#3) but not part of the first
-  release's acceptance.
-  <!-- TODO: confirm whether INT8 is accepted in 2.2 or the next cycle. -->
+- Quantized inference. Executing a W4A16 / W8A16 / W8A8 product is the
+  serving stack's job. `compressed-tensors` describes and stores the
+  weights; it does not imply a kernel exists on a given chip.
+  vllm-plugin-FL#313 landed compressed-tensors W4A16 scaffolding without
+  kernels, so an end-to-end serving claim depends on further work there.
+- Quantization-aware training.
+- Calibration-dataset-based methods. GPTQ, AWQ, and native AutoRound
+  (PR #6) merged to `main` after the release branch was cut and are not in
+  v0.1.0 or in this FEP's acceptance. `method: mse` is the only value the
+  v0.1.0 recipe schema accepts.
+- Preserving a source low-precision format for unselected weights.
+  `unselected.strategy: preserve` is parsed but rejected; it needs a
+  runtime config exporter and a matching inference kernel first. The only
+  supported policy is convert-to-BF16.
+- Downloading models, and judging whether a quantized model meets a
+  downstream accuracy bar. Both are the caller's responsibility.
 
 ## Proposal
 
-A command-line tool (`flagos-compressor`) with three verbs:
+A command-line tool, `flagos-compressor`, with four subcommands:
 
-- `inspect --input <model> [--json]` — report detected weight formats and
-  selectable groups.
-- `convert --input <model> --output <dir> --backend cpu|cuda` — dequantize
-  everything to BF16.
-- `quantize --input <model> --output <dir> --select <group> --method mse
-  --group-size 32 --backend cuda` — quantize the selected modules to INT4
-  W4A16; unselected source-quantized weights default to BF16.
+- `inspect --input <model> [--json]` — report detected source weight
+  formats and the count of selectable weights per group.
+- `convert --input <model> --output <dir> [--backend cpu|cuda]` —
+  dequantize recognized FP4/FP8 weights to BF16.
+- `quantize --input <model> --output <dir> --select <group> ...` —
+  quantize the selected weights; convert unselected source-quantized
+  weights to BF16.
+- `validate --input <dir> [--json]` — check a produced directory.
 
-Selection composes: repeated `--select`, regex `--select-name` /
-`--exclude-name`, group `--exclude`. A YAML recipe (version 1) expresses
-the same run declaratively. `--dry-run` previews the tensor plan without
-writing.
+Input and output must be different directories. A run is expected to go
+`inspect` → `quantize --dry-run` → `quantize` → `validate`, because
+`--dry-run` prints the resolved W/A bit widths, strategy, group size, the
+per-format tensor counts, and the count of scaled byte tensors whose layout
+was not recognized. That count must be zero before a real run; the tool
+refuses to guess an unrecognized layout rather than emitting silently wrong
+weights.
+
+Selection safety rules the planner enforces, all of which surface at
+`--dry-run` time:
+
+- A regex may not split a fused inference unit, and may not select part of
+  a routed-expert bank. Either the whole bank is quantized or none of it is.
+- Group quantization requires every selected layer's `in_features` to be
+  divisible by the group size; INT4 `pack-quantized` storage additionally
+  requires it divisible by 8.
+- `--strategy channel` is INT8-only, and is rejected for routed experts in
+  W8A16 because the vLLM WNA16 routed-MoE path requires group
+  quantization. Per-channel routed experts are reachable only through W8A8.
+- W8A8 requires `--bits 8 --activation-bits 8 --strategy channel` and
+  rejects `--group-size`.
+
+`validate` checks shard/index agreement, that every manifest-declared
+weight and scale exists with the expected dtype and storage shape, that
+INT4/INT8 logical shape metadata is self-consistent, and that
+`config.json`'s runtime quantization config matches the manifest. It does
+not load the model, so `Valid` is a statement about the directory, not
+about any inference stack or chip.
 
 ## Design Details
 
-Package layout (`src/flagos_compressor/`): `cli` (verbs), `core`
-(pipeline), `inspect` (model profiling), `io` (sharded safetensors
-read/write), `formats` (per-format encode/decode: bf16, fp4_e2m1,
-fp8_e8m0, floating, int4_pack, compressed_tensors, compressed_tensors_moe),
-`quantizers` (mse_int4 + registry), `backends` (cpu, cuda, op registry).
-Format and quantizer handlers register through their `register.py`
-modules, so new formats/methods extend without core changes.
+Package layout under `src/flagos_compressor/`: `cli` (the four
+subcommands and shared argument/recipe helpers), `core` (policy, planner,
+plan, executor, MoE layout adapters, reporting, validation), `inspect`
+(checkpoint scan, tensor classification, weight/scale pairing), `io`
+(sharded safetensors read and write), `formats` (per-format encode and
+decode: `bf16`, `floating`, `fp4_e2m1`, `fp8_e8m0`, `int4_pack`,
+`int8_pack`, `compressed_tensors`, `compressed_tensors_moe`),
+`quantizers` (`mse_int4`, `mse_int8` over a shared `mse_int` core),
+`backends` (`cpu`, `cuda`, op registry). Formats and quantizers register
+through `register.py` modules, so a new format or method is added without
+editing the planner.
 
-<!-- TODO: numerical acceptance for dequant/quant (tolerance vs reference,
-     or downstream-eval-based), and large-model memory strategy
-     (streaming/shard-wise processing limits). -->
+Fused 3D routed-expert banks get their axis order from a `MoeLayout`
+adapter chosen by `config.json` (`model_type`, nested `text_config`
+`model_type`, then `architectures`), not from the tensor name. This is
+deliberate: Qwen3.5-MoE stores `[num_experts, out, in]` while Qwen3-VL-MoE
+stores `[num_experts, in, out]`, and both use the same
+`experts.gate_up_proj` / `experts.down_proj` names. Selecting by name would
+quantize along the wrong axis for one of them, so v0.1.0 registers only the
+verified Qwen3.5-MoE layout and raises
+`Fused routed-expert quantization is not supported for this model` for
+anything else. On quantization the bank is expanded into standard
+`experts.<id>.<projection>` weight and scale names.
+
+Peak memory during the MSE search is bounded by a group chunk size
+(`--chunk-size`, default 4096 for INT4 and 1024 for INT8) rather than by
+holding a whole layer's candidate set.
+
+Each run writes machine-readable provenance next to the weights:
+`quantization_manifest.json` (schema `flagos-compressor.provenance.v1`:
+per-tensor format, bit width, strategy, scale name, storage and logical
+shape) and `quantization_report.json` (counts, elapsed time, requested
+backend, actual backend, and any per-op CPU fallback). `convert` writes
+`conversion_report.json`.
+
+<!-- TODO: numerical acceptance criteria for the dequantization and
+     quantization paths — tolerance against a reference dequantization, or
+     a downstream-eval-based bar. -->
+
+<!-- TODO: documented upper bound on model size per host memory
+     configuration, given the shard-wise processing and chunked search. -->
 
 ## Packaging
 
-- **Format:** Python package, `pip install -e .` from source
-  (`pyproject.toml`; `src/` layout).
-- **Entry point:** `flagos-compressor` CLI.
-- **Dependencies:** torch (CPU or CUDA build per backend), safetensors.
-  <!-- TODO: pin versions; confirm whether a PyPI wheel is published for
-       2.2 or source-install only. -->
+**Supported vendors:** compression runs on CPU or NVIDIA CUDA. v0.1.0's
+`--backend` accepts `cpu` and `cuda` only, so other vendors are covered by
+generating the product on a CPU or CUDA host and validating the load on the
+target chip. Load and accuracy acceptance is planned on NVIDIA GPU, PPU,
+and Hygon DCU.
+
+**Can this feature be packaged as a wheel (`.whl`)?** Yes. `pyproject.toml`
+uses a setuptools build backend and a `src/` layout, so a wheel builds
+with:
+
+```bash
+python -m build          # produces dist/flagos_compressor-0.1.0-*.whl
+# or
+pip wheel . -w dist/
+```
+
+Source install for the acceptance runs below:
+
+```bash
+git clone https://github.com/flagos-ai/FlagOS-Compressor.git
+cd FlagOS-Compressor
+git switch release/v0.1.0
+python -m pip install -e .
+```
+
+Either way the install provides the `flagos-compressor` entry point.
+
+**Platform requirements:** Python >= 3.10. Runtime dependencies: `torch`
+(CPU or CUDA build, matching the chosen backend), `safetensors`, `tqdm`,
+`PyYAML`. For `--backend cuda`, a CUDA-enabled torch build and a matching
+driver.
+
+<!-- TODO: pin dependency lower bounds, and confirm whether 2.2 publishes a
+     wheel to an index or stays source-install. -->
 
 ## Test Plan
 
-**(Required)** The repository has a `tests/` suite; acceptance for 2.2:
+**(Required)** The repository carries a `tests/` suite covering the tensor
+classifier, policy and planner, INT4 and INT8 quantization, fused MoE INT4,
+FP4 decoding, recipes, compressed-tensors config, and an end-to-end path:
+
+```bash
+python -m pytest tests/
+```
+
+Expected result: all tests pass on the `release/v0.1.0` branch.
+
+Acceptance for 2.2 is the model-level matrix below. All cases share these
+variables and run against a checked-out `release/v0.1.0`; every case records
+the output of `git rev-parse HEAD`:
+
+```bash
+MODEL_QWEN_DENSE=/data/models/qwen3.5-dense
+MODEL_QWEN_MOE=/data/models/qwen3.5-moe
+MODEL_DEEPSEEK=/data/models/deepseek
+OUT=/data/models/flagos-compressor-tests
+```
+
+Every quantization case runs the same command twice, first with `--dry-run`
+and then without, followed by `validate`. Shared expected results for all
+cases, checked at `--dry-run`:
+
+- The `quantization` line reports the intended W/A bit widths, strategy, and
+  group size.
+- `unmatched quantized: 0`.
+- The selectors match weights; no
+  `selectors did not match any supported tensors`.
+- No fused-pair, expert-bank-closure, or group-size divisibility error.
+
+And after the real run: `validate` prints `Valid` on the first line, and the
+output directory contains `quantization_manifest.json` and
+`quantization_report.json` with no unexplained CPU fallback in the report.
+
+### G1 — BF16 dequantization
+
+Feature: MXFP4 / block FP8 → BF16.
+
+```bash
+flagos-compressor inspect --input /data/models/source-low-precision
+flagos-compressor convert \
+  --input /data/models/source-low-precision \
+  --output "$OUT/source-bf16" \
+  --backend cuda
+flagos-compressor validate --input "$OUT/source-bf16"
+```
+
+Expected result: `inspect` reports the source weights as `fp4_e2m1_e8m0` or
+`fp8_block_e8m0` with `unmatched quantized: 0`; `convert` writes a BF16
+directory plus `conversion_report.json`; `validate` prints `Valid`. On a
+BF16 or FP16 input, `convert` instead fails with
+`No supported FP8/FP4 tensors were found`, which is the correct behavior and
+is recorded as such. Numerical check against a reference dequantization is
+pending the tolerance TODO above.
+
+### G2 — INT4 / INT8 export
+
+Feature: W4A16, W8A16 group, W8A16 channel, W8A8. Run on
+`$MODEL_QWEN_DENSE`, varying only the quantization flags:
+
+```bash
+# W8A16 group-128 — the conservative baseline, generated first
+flagos-compressor quantize --input "$MODEL_QWEN_DENSE" \
+  --output "$OUT/dense-w8a16-g128" \
+  --select linear --bits 8 --strategy group --group-size 128 --backend cuda
+
+# W4A16 group-32 — maximum weight compression
+flagos-compressor quantize --input "$MODEL_QWEN_DENSE" \
+  --output "$OUT/dense-w4a16-g32" \
+  --select linear --bits 4 --strategy group --group-size 32 --backend cuda
+
+# W8A8 channel + dynamic per-token
+flagos-compressor quantize --input "$MODEL_QWEN_DENSE" \
+  --output "$OUT/dense-w8a8" \
+  --select linear --bits 8 --activation-bits 8 --strategy channel \
+  --backend cuda
+
+# W8A16 channel, attention only
+flagos-compressor quantize --input "$MODEL_QWEN_DENSE" \
+  --output "$OUT/dense-attn-w8a16-channel" \
+  --select attention --bits 8 --strategy channel --backend cuda
+```
+
+Expected results: the shared checks above, plus each product's
+`config.json` declares the expected `compressed-tensors` scheme —
+`pack-quantized` for W4A16 and W8A16, `int-quantized` for W8A8 — and the
+manifest reports the matching weight encoding. The attention-only case
+additionally shows unselected linear weights listed in the config's ignore
+set. Directory sizes compare as expected against the source:
+
+```bash
+du -sh "$MODEL_QWEN_DENSE" "$OUT/dense-w8a16-g128" \
+  "$OUT/dense-w4a16-g32" "$OUT/dense-w8a8"
+```
+
+### G3 — Selection and recipe
+
+Feature: group and regex selection, and recipe equivalence.
+
+```bash
+# regex exclude on top of a group selection
+flagos-compressor quantize --input "$MODEL_QWEN_DENSE" \
+  --output "$OUT/dense-attn-skip-layer0" \
+  --select attention --exclude-name '.*\.layers\.0\..*' \
+  --bits 8 --strategy group --group-size 128 --backend cuda --dry-run
+
+# the same run expressed as a recipe
+flagos-compressor quantize --input "$MODEL_QWEN_MOE" \
+  --output "$OUT/moe-w8a8-recipe" \
+  --recipe /data/recipes/w8a8-linear.yaml --backend cuda
+```
+
+with `/data/recipes/w8a8-linear.yaml`:
+
+```yaml
+version: 1
+bits: 8
+activation_bits: 8
+strategy: channel
+method: mse
+n_candidates: 200
+chunk_size: 1024
+select:
+  - linear
+unselected:
+  strategy: convert
+  format: bf16
+```
+
+Expected results: the exclude case's dry-run plan shows layer 0's attention
+weights absent from the quantized counts and present in the kept counts;
+the recipe run produces a plan and a product equivalent to the matching
+all-CLI W8A8 run. Negative cases expected to fail with the quoted message:
+`--select-name` matching one half of a fused pair gives
+`The selection splits fused inference units`; no selector at all gives
+`No weights selected`; `--strategy channel --group-size 128` gives
+`group_size must be omitted for channel strategy`; a routed-expert
+selection with `--strategy channel` and 16-bit activations is rejected with
+the W8A16 routed-MoE message.
+
+### G4 — Model coverage
+
+Feature: dense, fused 3D MoE, and MLA / 2D MoE structures.
+
+```bash
+flagos-compressor inspect --input "$MODEL_QWEN_MOE" --json > moe-inspect.json
+
+# routed experts only, W4A16
+flagos-compressor quantize --input "$MODEL_QWEN_MOE" \
+  --output "$OUT/moe-routed-w4a16-g32" \
+  --select moe.routed --bits 4 --strategy group --group-size 32 \
+  --backend cuda
+
+# routed experts + attention, W8A16
+flagos-compressor quantize --input "$MODEL_QWEN_MOE" \
+  --output "$OUT/moe-routed-attn-w8a16-g128" \
+  --select moe.routed --select attention \
+  --bits 8 --strategy group --group-size 128 --backend cuda
+
+# whole-model W8A8, exercising fused-expert expansion
+flagos-compressor quantize --input "$MODEL_QWEN_MOE" \
+  --output "$OUT/moe-w8a8" \
+  --select linear --bits 8 --activation-bits 8 --strategy channel \
+  --backend cuda
+
+# DeepSeek-class: MLA + 2D experts
+flagos-compressor quantize --input "$MODEL_DEEPSEEK" \
+  --output "$OUT/deepseek-w8a16-g128" \
+  --select linear --bits 8 --strategy group --group-size 128 --backend cuda
+
+flagos-compressor quantize --input "$MODEL_DEEPSEEK" \
+  --output "$OUT/deepseek-routed-w4a16-g32" \
+  --select moe.routed --bits 4 --strategy group --group-size 32 \
+  --backend cuda
+```
+
+Expected results: `inspect` group counts match the model's real structure —
+routed-expert counts present on the MoE models and absent on the dense
+model, MLA projection counts present on DeepSeek. For the Qwen3.5-MoE W8A8
+product, the manifest carries expanded
+`experts.<id>.<projection>.weight` and `weight_scale` entries rather than
+fused bank names. A model with a fused 3D expert bank and no registered
+layout must fail before writing weights, with
+`Fused routed-expert quantization is not supported for this model`; that
+guard is not to be bypassed for acceptance.
+
+One case applies to any model whose `self_attn` contains an auxiliary
+`indexer` submodule. Its inner weights carry attention-like leaf names, so
+`--select attention` picks them up even though they are not a general
+quantization target. Check whether a candidate model has them, and exclude
+them if so:
+
+```bash
+grep -o 'self_attn\.indexer' "$INPUT/model.safetensors.index.json" | head -1
+
+flagos-compressor quantize --input "$INPUT" --output "$OUT/attn-moe-w8a8" \
+  --select attention --select moe \
+  --exclude-name '.*\.self_attn\.indexer\..*\.weight$' \
+  --bits 8 --activation-bits 8 --strategy channel --backend cuda --dry-run
+```
+
+Expected result: with the exclusion in place the plan resolves and the
+indexer weights appear in the kept counts instead of the quantized ones.
+
+### G5 — Backends
+
+Feature: `--backend cpu` and `--backend cuda`.
+
+```bash
+flagos-compressor quantize --input "$MODEL_QWEN_DENSE" \
+  --output "$OUT/dense-w8a16-g128-cpu" \
+  --select linear --bits 8 --strategy group --group-size 128 --backend cpu
+
+flagos-compressor quantize --input "$MODEL_QWEN_DENSE" \
+  --output "$OUT/dense-w8a16-g128-cuda" \
+  --select linear --bits 8 --strategy group --group-size 128 \
+  --backend cuda --device cuda:0
+```
+
+Expected result: both runs validate, and the two products agree on manifest
+metadata, storage shapes, and scheme. Numerical agreement between the two
+backends is bounded by the tolerance TODO above. On a host without CUDA,
+`--backend cuda` is expected to fail with `backend 'cuda' is unavailable`.
+
+### Serving-side verification
+
+Every product is checked for load on a compressed-tensors-capable stack,
+recording the inference framework, torch, driver, and device runtime
+versions, whether the log reports the intended scheme, and whether any
+kernel fallback occurred. A BF16 or source-float reference is served on the
+same stack for an accuracy A/B, and peak memory, TTFT, TPOT, and throughput
+are recorded alongside it. Load and accuracy acceptance is planned on
+NVIDIA GPU, PPU, and Hygon DCU; each target is verified independently, since
+a valid product does not imply a kernel exists on a given chip.
+
+A `Valid` product that fails to load is a serving-side result, not a
+product-side one, and is recorded against the stack and chip rather than
+against this FEP's G1–G5.
+
+<!-- TODO: name the serving stack and version used for the load tests, and
+     the accuracy datasets for the A/B, once vllm-plugin-FL's
+     compressed-tensors kernel support is settled (see #313). -->
 
 | Goal | Verification | Status |
 |---|---|---|
-| G1: dequant paths | FP4/FP8 → BF16 conversion on models in each input format; numerical check vs reference dequant <!-- TODO: tolerance --> | Pending |
-| G2: INT4 W4A16 | Quantized output loads as compressed-tensors pack-quantized and serves in a compressed-tensors-capable stack <!-- TODO: serving stack + model for the load test --> | Pending |
-| G3: Selector/Recipe | Group/regex selection unit tests; recipe run reproduces the equivalent CLI run; `--dry-run` plan matches actual writes | Pending |
-| G4: model coverage | Convert + quantize on a DeepSeek-V3-class MoE, a Qwen MoE, and a Qwen dense checkpoint (sharded) | Pending |
-| G5: backends | Same inputs produce equivalent outputs on `--backend cpu` and `--backend cuda` | Pending |
+| G1: dequantization | MXFP4 / block FP8 → BF16 convert + validate; expected refusal on float input | Pending |
+| G2: INT4/INT8 export | W4A16, W8A16 group, W8A16 channel, W8A8 products validate with the declared scheme | Pending |
+| G3: selection + recipe | Group/regex selection and recipe equivalence; guard messages on the negative cases | Pending |
+| G4: model coverage | Qwen3.5 dense, Qwen3.5-MoE (fused 3D), DeepSeek-class (MLA + 2D experts) | Pending |
+| G5: backends | Equivalent products from `--backend cpu` and `--backend cuda` | Pending |
+| Serving | Load + accuracy A/B on NVIDIA GPU, PPU, Hygon DCU with versions recorded | Pending |
 
 ## Related PRs
 
 - [x] flagos-ai/FlagOS-Compressor#1 — feat: bootstrap FlagCompressor — safetensors weight-format conversion with BF16 dequant and policy-driven INT4 quantization
 - [x] flagos-ai/FlagOS-Compressor#2 — feat: support fused MoE INT4 packing and compressed-tensors output
 - [x] flagos-ai/FlagOS-Compressor#3 — feat(quantization): add INT8 weight quantization
+- [x] flagos-ai/FlagOS-Compressor#4 — refactor(cli): log operational summaries
+- [x] flagos-ai/FlagOS-Compressor#5 — feat(quantization): add dynamic-token W8A8 MoE export
+
+PRs #1–#5 are the content of `release/v0.1.0`.
+flagos-ai/FlagOS-Compressor#6 (calibrated GPTQ, AWQ, and native AutoRound)
+merged to `main` after the branch was cut and is out of scope for 2.2.
+
+Serving side, tracked separately: flagos-ai/vllm-plugin-FL#313 —
+feat(quantization): add compressed-tensors W4A16 scaffolding (kernels not
+included), merged 2026-07-29.
 
 ## Implementation History
 
-- 2026-07-30: FEP created as `Provisional` for the FlagOS 2.2 cycle;
-  repository bootstrapped 2026-07-14.
+- 2026-07-14: repository bootstrapped.
+- 2026-07-30: FEP created as `Provisional` for the FlagOS 2.2 cycle.
+- 2026-08-04: `release/v0.1.0` cut at commit `eecf2fa`, after PR #5.
+- 2026-08-25: FEP scope aligned to the release branch — INT8, per-channel
+  INT8, and dynamic-token W8A8 moved from Non-Goals into G2; calibrated
+  methods recorded as out of scope; Test Plan rewritten with the acceptance
+  commands and expected results.

--- a/fep/sig-framework/flagos-compressor-first-release.md
+++ b/fep/sig-framework/flagos-compressor-first-release.md
@@ -1,0 +1,155 @@
+# FEP: FlagOS-Compressor — Model Quantization Framework (First Release)
+
+**Status:** `Provisional`
+
+**Created:** 2026-07-30
+
+**Owner:** [TODO: @github-username]
+
+**SIG:** sig-framework
+
+**Target Version:** FlagOS 2.2
+
+---
+
+## Summary
+
+**(Required)** This FEP proposes the first release of **FlagOS-Compressor**
+(initially bootstrapped as FlagCompressor, renamed FlagOS-Compressor), the
+FlagOS model quantization and weight-format conversion framework, in the
+FlagOS 2.2 cycle. It converts and quantizes HuggingFace `safetensors`
+checkpoints:
+
+1. **BF16 dequantization** — end-to-end FP4 (E2M1 + E8M0) / FP8 (block +
+   E8M0) → BF16 dequantization, with BF16 pass-through.
+2. **INT4 weight quantization** — groupwise MSE INT4 with BF16 scales,
+   written directly as an inference-ready compressed-tensors
+   `pack-quantized` W4A16 checkpoint.
+3. **Selector + Recipe** — built-in selection groups (`moe`, `moe.routed`,
+   `moe.shared`, `attention`, `mlp`) combinable via `--select`; unselected
+   low-precision weights are converted to BF16 or kept, enabling
+   mixed-precision outputs.
+4. **Dry-run + inspect** — `--dry-run` previews the execution plan;
+   `inspect --json` emits a machine-readable model profile.
+
+As a new module and repository, this FEP also serves as the module's
+admission proposal per the FEP rules ("New module / new repository:
+Required").
+
+Repository: https://github.com/flagos-ai/FlagOS-Compressor
+
+## Motivation
+
+Mainstream open checkpoints increasingly ship in low-precision storage
+formats (MXFP4, block FP8), while the chips FlagOS targets differ in which
+formats they can execute. Deploying one model across the FlagOS chip fleet
+therefore needs a format bridge: dequantize vendor-incompatible formats to
+BF16, or re-quantize selected weights to widely-executable INT4 (W4A16) —
+with module-level control, because MoE experts, attention, and MLP weights
+have different sensitivity and different hardware support. Existing
+one-shot conversion scripts do not offer selection, mixed-precision
+products, or reproducible recipes; FlagOS-Compressor provides these as a
+first-class FlagOS component.
+
+### Goals
+
+**(Required)**
+
+- **G1 (BF16 dequantization):** FP4 (E2M1 + E8M0) and FP8 (block + E8M0)
+  inputs dequantize end-to-end to BF16; BF16 inputs pass through. Format
+  handlers in-tree: `fp4_e2m1`, `fp8_e8m0`, `bf16`, `floating`.
+- **G2 (INT4 quantization):** Groupwise MSE INT4 (`quantizers/mse_int4.py`,
+  default group size 32) with BF16 scales, emitting compressed-tensors
+  `pack-quantized` W4A16 output (`formats/int4_pack.py`,
+  `compressed_tensors.py`, `compressed_tensors_moe.py` — fused-MoE INT4
+  packing landed in #2) and updating `config.json`; no post-quantization
+  conversion step.
+- **G3 (Selector + Recipe):** Built-in groups `moe` / `moe.routed` /
+  `moe.shared` / `attention` / `mlp` (plus `linear`), name-pattern
+  select/exclude, unselected-weight strategy (convert-to-BF16 or keep), and
+  a versioned YAML recipe format capturing method / group size / selection
+  for reproducible runs.
+- **G4 (Model coverage):** Sharded HuggingFace safetensors input (models
+  with a `model.safetensors.index.json`); conversion and quantization paths
+  verified on mainstream MoE models (DeepSeek-V3-class, Qwen MoE class) and
+  mainstream dense models (Qwen dense class). Supported input storage
+  formats: MXFP4 (E2M1 + E8M0), block FP8 + E8M0, BF16.
+- **G5 (Hardware backends):** CPU (torch CPU backend) and CUDA (torch CUDA
+  backend, with the quantization search path GPU-accelerated), switchable
+  via `--backend cpu|cuda` (`backends/cpu.py`, `cuda.py`).
+
+### Non-Goals
+
+- Quantized *inference* — executing the W4A16 product is the serving
+  stack's job (e.g. vllm-plugin-FL, which is adding compressed-tensors
+  W4A16 support separately in flagos-ai/vllm-plugin-FL#313).
+- Quantization-aware training or calibration-dataset-based methods (PTQ
+  weight-only in this release; only the MSE method is accepted by the
+  recipe schema).
+- Activation quantization (W4A16 means activations stay 16-bit).
+- INT8 weight quantization — in progress (#3) but not part of the first
+  release's acceptance.
+  <!-- TODO: confirm whether INT8 lands in 2.2 or the next cycle. -->
+
+## Proposal
+
+A command-line tool (`flagos-compressor`) with three verbs:
+
+- `inspect --input <model> [--json]` — report detected weight formats and
+  selectable groups.
+- `convert --input <model> --output <dir> --backend cpu|cuda` — dequantize
+  everything to BF16.
+- `quantize --input <model> --output <dir> --select <group> --method mse
+  --group-size 32 --backend cuda` — quantize the selected modules to INT4
+  W4A16; unselected source-quantized weights default to BF16.
+
+Selection composes: repeated `--select`, regex `--select-name` /
+`--exclude-name`, group `--exclude`. A YAML recipe (version 1) expresses
+the same run declaratively. `--dry-run` previews the tensor plan without
+writing.
+
+## Design Details
+
+Package layout (`src/flagos_compressor/`): `cli` (verbs), `core`
+(pipeline), `inspect` (model profiling), `io` (sharded safetensors
+read/write), `formats` (per-format encode/decode: bf16, fp4_e2m1,
+fp8_e8m0, floating, int4_pack, compressed_tensors, compressed_tensors_moe),
+`quantizers` (mse_int4 + registry), `backends` (cpu, cuda, op registry).
+Format and quantizer handlers register through their `register.py`
+modules, so new formats/methods extend without core changes.
+
+<!-- TODO: numerical acceptance for dequant/quant (tolerance vs reference,
+     or downstream-eval-based), and large-model memory strategy
+     (streaming/shard-wise processing limits). -->
+
+## Packaging
+
+- **Format:** Python package, `pip install -e .` from source
+  (`pyproject.toml`; `src/` layout).
+- **Entry point:** `flagos-compressor` CLI.
+- **Dependencies:** torch (CPU or CUDA build per backend), safetensors.
+  <!-- TODO: pin versions; confirm whether a PyPI wheel is published for
+       2.2 or source-install only. -->
+
+## Test Plan
+
+**(Required)** The repository has a `tests/` suite; acceptance for 2.2:
+
+| Goal | Verification | Status |
+|---|---|---|
+| G1: dequant paths | FP4/FP8 → BF16 conversion on models in each input format; numerical check vs reference dequant <!-- TODO: tolerance --> | Pending |
+| G2: INT4 W4A16 | Quantized output loads as compressed-tensors pack-quantized and serves in a compressed-tensors-capable stack <!-- TODO: serving stack + model for the load test --> | Pending |
+| G3: Selector/Recipe | Group/regex selection unit tests; recipe run reproduces the equivalent CLI run; `--dry-run` plan matches actual writes | Pending |
+| G4: model coverage | Convert + quantize on a DeepSeek-V3-class MoE, a Qwen MoE, and a Qwen dense checkpoint (sharded) | Pending |
+| G5: backends | Same inputs produce equivalent outputs on `--backend cpu` and `--backend cuda` | Pending |
+
+## Related PRs
+
+- [x] flagos-ai/FlagOS-Compressor#1 — feat: bootstrap FlagCompressor — safetensors weight-format conversion with BF16 dequant and policy-driven INT4 quantization
+- [x] flagos-ai/FlagOS-Compressor#2 — feat: support fused MoE INT4 packing and compressed-tensors output
+- [ ] flagos-ai/FlagOS-Compressor#3 — feat(quantization): add INT8 weight quantization
+
+## Implementation History
+
+- 2026-07-30: FEP created as `Provisional` for the FlagOS 2.2 cycle, from
+  the framework-group 2.2 release plan; repository bootstrapped 2026-07-14.


### PR DESCRIPTION
FEP for the first release (v0.1.0) of FlagOS-Compressor, the FlagOS weight-format conversion and quantization tool, in the FlagOS 2.2 cycle.

Scope is pinned to the release branch [`release/v0.1.0`](https://github.com/flagos-ai/FlagOS-Compressor/tree/release/v0.1.0) (cut at `eecf2fa`, tagged `v0.1.0-rc1`), not `main`:

- BF16 dequantization of MXFP4 (E2M1 + E8M0) and block FP8 (128x128 tile + E8M0).
- Weight-only MSE INT4/INT8 → compressed-tensors W4A16 and W8A16 (`pack-quantized`), plus dynamic per-token W8A8 (`int-quantized`).
- Module selection (`linear`, `attention`, `mlp`, `moe`, `moe.routed`, `moe.shared`), regex select/exclude, and versioned YAML recipes.
- `inspect`, `--dry-run`, `validate`; CPU and CUDA backends.
- Structural coverage: dense, 2D routed/shared experts, MLA attention naming, and fused 3D routed-expert banks for the one registered layout (Qwen3.5-MoE).

Notable scope corrections made by checking the release branch rather than `main`:

- INT8, per-channel INT8, and W8A8 (PRs #3/#5) are in the release branch, so they are Goals now, not Non-Goals.
- Calibrated GPTQ/AWQ/AutoRound (PR #6) merged to `main` after the branch was cut and is out of scope for 2.2.
- `--backend` accepts `cpu` and `cuda` only; other chips are covered by generating on a CPU/CUDA host and validating the load on target.
- Only the Qwen3.5-MoE fused-expert axis order is registered; other layouts are refused rather than guessed.

New module and repository, so this FEP doubles as the module admission proposal.

Status is `Implementable`: implementation is complete on the release branch (PRs #1–#5 merged, `v0.1.0-rc1` tagged 2026-08-24) and the Test Plan carries executable commands with expected results. Owner: @rdzhu225. Acceptance runs during the 2.2 testing window flip it to `Implemented`. Open TODOs carried in doc comments, to be settled during acceptance: numerical tolerance for the dequant/quant checks, host-memory sizing guidance, dependency pins / wheel publication, and the serving stack + datasets for the load tests. Feature Freeze for 2.2 is 2026-08-31.