### PR TITLE
release: cut flagos-compressor rc0 from release/v0.1.0

### DIFF
--- a/release/2.2/release-2.2-rc0.yaml
+++ b/release/2.2/release-2.2-rc0.yaml
@@ -208,7 +208,7 @@ repositories:
     version: v0.1.0-rc0.post1
     # 分支: 0.1.0-rc0
     # 基线分支: release/v0.1.0
-    # 当前版本: v0.1.0-rc1 / 默认分支: main
+    # 当前版本: 无已发布 tag / 默认分支: main
     # 注: 2.2 新增模块（FEP #91 量化框架），2.1 清单中不存在
     # 注: rc0 从 release/v0.1.0 拉出，不从 main 拉；main 领先该发布分支 12 个提交，
     #     这些提交不进 2.2 rc0

--- a/release/2.2/release-2.2-rc0.yaml
+++ b/release/2.2/release-2.2-rc0.yaml
@@ -31,7 +31,8 @@
 # 注释字段说明（manage-release.py 依赖这两个字段）：
 #   - "分支:"     rc0 集成分支名，工具会创建并推送它
 #   - "基线分支:" rc0 分支从哪个上游分支拉出；缺省时取默认分支。
-#                同一仓库拆多个条目、各自跟不同上游线时必须写（见 FlagTree）
+#                同一仓库拆多个条目、各自跟不同上游线时必须写（见 FlagTree）；
+#                rc0 要从发布分支而非默认分支拉出时也必须写（见 flagos-compressor）
 #
 # ⚠️ 注意: FlagGems / FlagGems-sglang / FlagDNN / FlagBLAS 的默认分支是 master，
 #          其他模块都是 main。
@@ -206,8 +207,11 @@ repositories:
     url: https://github.com/flagos-ai/FlagOS-Compressor.git
     version: v0.1.0-rc0.post1
     # 分支: 0.1.0-rc0
+    # 基线分支: release/v0.1.0
     # 当前版本: v0.1.0-rc1 / 默认分支: main
     # 注: 2.2 新增模块（FEP #91 量化框架），2.1 清单中不存在
+    # 注: rc0 从 release/v0.1.0 拉出，不从 main 拉；main 领先该发布分支 12 个提交，
+    #     这些提交不进 2.2 rc0
 
   # ===========================================================================
   # L3 — 应用/工具层（编排框架 + 工具 + 文档）


### PR DESCRIPTION
## 背景

FlagOS-Compressor 的 2.2 rc0 需要基于发布分支 `release/v0.1.0` 拉出，而不是默认分支 `main`。#103 合入的清单里 `flagos-compressor` 条目缺少 `基线分支:` 字段，`manage-release.py` 会回退到默认分支，任何人重跑一次工具都会把 rc0 拉回 `main`。

`main` 领先 `release/v0.1.0` 12 个提交（含 PR #6 native-autoround-support、GLM/DeepSeek 校准结构修复），这些提交按此设定不进 2.2 rc0。

## 改动

- `flagos-compressor` 补 `# 基线分支: release/v0.1.0`
- 头部字段说明补上这一用法（原文只写了 FlagTree 那种同仓多条目的场景）
- `flagos-compressor` 的 `# 当前版本:` 改为「无已发布 tag」（原为 `v0.1.0-rc1`，该 tag 已删除，见下）

## 远端 ref 已重建

`FlagOS-Compressor` 上原先基于 `main` 的 rc0 已替换：

| ref | 旧 | 新 |
|---|---|---|
| 分支 `0.1.0-rc0` | `f286e1e4`（main HEAD） | `eecf2fae`（release/v0.1.0 HEAD） |
| tag `v0.1.0-rc0.post1` | `f286e1e4` | `eecf2fae` |

删除前已确认两个 ref 都指向 `main` 的 HEAD，即工具创建后无人推送过新提交。已从远端回读核对。

## v0.1.0-rc1 已按要求删除

原 `v0.1.0-rc1`（注释 tag `2aec5d0a`，指向 `eecf2fae`，2026-08-24 由 @rdzhu225 创建）已删除。删除前核对：无 GitHub Release 挂载，仓库内无代码/文档引用，目标提交 `eecf2fae` 仍是 `release/v0.1.0` 的 HEAD，故无提交失去可达路径。

如需恢复：

```
git tag -a v0.1.0-rc1 eecf2fae -m "FlagOS-Compressor v0.1.0 release candidate 1"
git push origin v0.1.0-rc1
```

仓库现有 tag 仅 `v0.1.0-rc0.post1`（→ `eecf2fae`），`main` 与 `release/v0.1.0` 均未改动。

## 验证

`--dry-run` 跑新清单，24 个模块全部解析正常，`flagos-compressor` 显示：

```
📦 flagos-compressor
   分支: 0.1.0-rc0  |  tag: v0.1.0-rc0.post1  |  基线分支: release/v0.1.0
```

其余 23 个条目的基线分支不变（17 main / 4 master / triton_v3.5.x / triton_v3.3.x）。

## 需要确认

清单中各模块的 2.2 目标版本号仍是按「次版本号 +1」推断的，无信源，跑正式 tag 前需 module owner 确认。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
