### PR TITLE
release: add vllm-plugin-FL release/0.2 line to 2.2 rc0

### DIFF
--- a/release/2.2/release-2.2-rc0.yaml
+++ b/release/2.2/release-2.2-rc0.yaml
@@ -171,14 +171,27 @@ repositories:
     # 当前版本: v0.1.0 / 默认分支: main
     # 注: 2.1 中名为 pytorch-plugin-fl，仓库已更名 PyTorch-Plugin-FL → Torch-FL
 
+  # vllm-plugin-FL 按 vLLM 版本线拆两个条目，指向同一仓库的不同分支，2.2 两条线都测：
+  #   - main        跟 vLLM 0.24.0 → 0.3.0-rc0
+  #   - release/0.2 跟 vLLM 0.20.2 → 0.2.2-rc0
   vllm-plugin-fl:
     type: git
     url: https://github.com/flagos-ai/vllm-plugin-FL.git
     version: v0.3.0-rc0.post1
     # 分支: 0.3.0-rc0
+    # 基线分支: main
     # 当前版本: v0.2.1 / 默认分支: main
     # 注: 2.1 正式版为 v0.2.0，其后 main 上已发 v0.2.1；
     #     上游已存在 v0.3.0-rc0 tag（非本流程所打），本次 rc0 tag 用 .post1 后缀区分
+
+  vllm-plugin-fl-0.2:
+    type: git
+    url: https://github.com/flagos-ai/vllm-plugin-FL.git
+    version: v0.2.2-rc0.post1
+    # 分支: 0.2.2-rc0
+    # 基线分支: release/0.2
+    # 当前版本: v0.2.1 / 默认分支: main
+    # 注: release/0.2 线（vLLM 0.20.2），该线最新 tag v0.2.1，release/0.2 领先其 6 个提交
 
   sglang-plugin-fl:
     type: git


### PR DESCRIPTION
## 背景

vllm-plugin-FL 2.2 需要测两条线，清单原来只覆盖 main 一条：

| 线 | 跟随 vLLM | rc0 分支 | rc0 tag |
|---|---|---|---|
| `main` | 0.24.0（README 安装指令） | `0.3.0-rc0`（已建） | `v0.3.0-rc0.post1`（已打） |
| `release/0.2` | 0.20.2（该分支 README 安装指令） | `0.2.2-rc0`（待建） | `v0.2.2-rc0.post1`（待打） |

## 改动

- 新增 `vllm-plugin-fl-0.2` 条目：`基线分支: release/0.2`，分支 `0.2.2-rc0`，tag `v0.2.2-rc0.post1`
- 原 `vllm-plugin-fl` 条目补 `基线分支: main` 注释，条目头记录两条线的对应关系

版本号依据：`release/0.2` 线最新 tag 为 `v0.2.1`，该分支领先其 6 个提交，故 rc0 取 `0.2.2`。

## 验证

- `--dry-run` 25/25 解析通过，新条目正确显示 `基线分支: release/0.2`
- 已确认远端不存在 `0.2.2-rc0` 分支和 `v0.2.2-rc0.post1` tag，不会撞已有 ref
- 重跑 manage-release.py 对已存在的分支/tag 会跳过，只会新建这一对

## 合入后

需要跑一次 `manage-release.py`（或 Actions 里的 Release Branch & Tag workflow）来实际创建 `0.2.2-rc0` 分支和 tag——本 PR 只改清单，不动 vllm-plugin-FL 仓库。

🤖 Generated with [Claude Code](https://claude.com/claude-code)